### PR TITLE
Update pki provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
       - master
   merge_group:
   schedule:
-    - cron: '30 13 * * 1,5'
+    - cron: '30 13 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -61,6 +61,9 @@ jobs:
         shell: bash
         env:
           RUST_BACKTRACE: 1
+
+      - name: cargo build (debug; rustls-mbedtls-provider-examples)
+        run: cargo build --locked -p rustls-mbedtls-provider-examples
 
   features:
     name: Features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; no default features)
-        run: cargo test --locked --no-default-features
+        run: cargo test --locked --no-default-features --workspace
 
       - name: cargo test (rustls_mbedcrypto_provider; debug; no default features; tls12)
         run: cargo test --locked --no-default-features --features tls12 --package rustls-mbedcrypto-provider
@@ -95,7 +95,7 @@ jobs:
         run: cargo test --locked --no-default-features --features tls12,rdrand --package rustls-mbedcrypto-provider
 
       - name: cargo test (release; no run)
-        run: cargo test --locked --release --no-run
+        run: cargo test --locked --release --no-run --workspace
 
 # TODO: add fuzz tests
 # TODO: add benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,25 +638,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.0-alpha.4"
 source = "git+https://github.com/rustls/rustls?rev=b776a5778ad333653670c34ff9125d8ae59b6047#b776a5778ad333653670c34ff9125d8ae59b6047"
 dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.6",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -668,10 +656,10 @@ dependencies = [
  "env_logger",
  "log",
  "mbedtls",
- "rustls 0.22.0-alpha.4",
+ "rustls",
  "rustls-pemfile 2.0.0-alpha.1",
  "rustls-pki-types",
- "rustls-webpki 0.102.0-alpha.6",
+ "rustls-webpki",
  "webpki-roots",
 ]
 
@@ -681,8 +669,9 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "mbedtls",
- "rustls 0.21.8",
+ "rustls",
  "rustls-pemfile 1.0.3",
+ "rustls-pki-types",
  "x509-parser",
 ]
 
@@ -713,32 +702,12 @@ checksum = "a47003264dea418db67060fa420ad16d0d2f8f0a0360d825c00e177ac52cb5d8"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
 version = "0.102.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d9ed3a8267782ba32d257ff5b197b63eef19a467dbd1be011caaae35ee416e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
  "untrusted",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedcrypto-provider"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "env_logger",
  "log",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedpki-provider"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "mbedtls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +692,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-mbedtls-provider-examples"
+version = "0.1.0"
+dependencies = [
+ "env_logger",
+ "rustls",
+ "rustls-mbedcrypto-provider",
+ "rustls-mbedpki-provider",
+ "rustls-native-certs",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.3",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +748,38 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,4 @@
 [workspace]
-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
+members = ["examples","rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
 default-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
 resolver = "2"
-
-[workspace.dependencies]
-mbedtls = { version = "0.12.0-alpha.2", default_features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,8 +2,9 @@
 name = "rustls-mbedtls-provider-examples"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "MPL-2.0"
+description = "rustls-mbedtls-provider example code."
+publish = false
 
 [dependencies]
 rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rustls-mbedtls-provider-examples"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider" }
+rustls-mbedpki-provider = { path = "../rustls-mbedpki-provider" }
+env_logger = "0.10"
+# TODO: upgrade to use formal 0.22.0 or 0.22.0-* versions when availabe
+rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default-features = false }
+rustls-native-certs = "0.6.3"
+

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -1,0 +1,56 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+**/
+
+use std::io::{stderr, stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use rustls_mbedcrypto_provider::MBEDTLS;
+use rustls_mbedpki_provider::MbedTlsServerCertVerifier;
+
+fn main() {
+    env_logger::init();
+
+    let root_certs: Vec<_> = rustls_native_certs::load_native_certs()
+        .expect("could not load platform certs")
+        .into_iter()
+        .map(|cert| cert.0.into())
+        .collect();
+    let server_cert_verifier = MbedTlsServerCertVerifier::new(&root_certs).unwrap();
+    let config = rustls::ClientConfig::builder_with_provider(MBEDTLS)
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(server_cert_verifier))
+        .with_no_client_auth();
+
+    let server_name = "www.rust-lang.org".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut sock = TcpStream::connect("www.rust-lang.org:443").unwrap();
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        concat!(
+            "GET / HTTP/1.1\r\n",
+            "Host: www.rust-lang.org\r\n",
+            "Connection: close\r\n",
+            "Accept-Encoding: identity\r\n",
+            "\r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    writeln!(&mut stderr(), "Current ciphersuite: {:?}", ciphersuite.suite()).unwrap();
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    stdout().write_all(&plaintext).unwrap();
+}

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedcrypto-provider"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "Mbedtls based crypto provider for rustls."

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4" }
 mbedtls = { version = "0.12.0-alpha.2", features = [
     "x509",
     "chrono",
@@ -20,6 +20,7 @@ mbedtls = { version = "0.12.0-alpha.2", features = [
 
 x509-parser = "0.15"
 chrono = "0.4"
+pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"] }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedpki-provider"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "Implements rustls PKI traits using mbedtls"

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4" }
+rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default_features = false }
 mbedtls = { version = "0.12.0-alpha.2", features = [
     "x509",
     "chrono",
@@ -20,7 +20,9 @@ mbedtls = { version = "0.12.0-alpha.2", features = [
 
 x509-parser = "0.15"
 chrono = "0.4"
-pki-types = { package = "rustls-pki-types", version = "0.2.1", features = ["std"] }
+pki-types = { package = "rustls-pki-types", version = "0.2.1", features = [
+    "std",
+] }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc
@@ -33,3 +35,4 @@ mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
 
 [dev-dependencies]
 rustls-pemfile = "1.0"
+rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4" }


### PR DESCRIPTION
- Update pki provider to use newer rustls to sync up with crypto provider.
- No default feature on rustls in pki provider to avoid dependency on `ring`
- Add a full example of using crypto and pki provider to create a TLS client.