### PR TITLE
Upgrade to use rustls 0.22.0-alpha.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_RETRY: 10
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ admin/rustfmt
 **/._.DS_Store
 /.idea
 /default.profraw
+.cargo/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,7 +422,7 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "yasna",
+ "yasna 0.2.2",
 ]
 
 [[package]]
@@ -670,6 +676,7 @@ dependencies = [
 name = "rustls-mbedcrypto-provider"
 version = "0.0.1-alpha.1"
 dependencies = [
+ "bit-vec 0.6.3",
  "env_logger",
  "log",
  "mbedtls",
@@ -679,6 +686,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "webpki-roots",
+ "yasna 0.3.2",
 ]
 
 [[package]]
@@ -1152,8 +1160,17 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.5.1",
  "num-bigint 0.2.6",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec 0.6.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,7 +655,8 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.22.0-alpha.4"
-source = "git+https://github.com/rustls/rustls?rev=b776a5778ad333653670c34ff9125d8ae59b6047#b776a5778ad333653670c34ff9125d8ae59b6047"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c23376606de66c7b9249d091b59ee55b52df72063e1cae7bb44e0691c9e5150"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "log",
  "mbedtls",
  "rustls",
+ "rustls-mbedtls-provider-utils",
  "rustls-pemfile 2.0.0-alpha.1",
  "rustls-pki-types",
  "rustls-webpki",
@@ -687,6 +688,7 @@ dependencies = [
  "chrono",
  "mbedtls",
  "rustls",
+ "rustls-mbedtls-provider-utils",
  "rustls-pemfile 1.0.3",
  "rustls-pki-types",
  "x509-parser",
@@ -701,6 +703,15 @@ dependencies = [
  "rustls-mbedcrypto-provider",
  "rustls-mbedpki-provider",
  "rustls-native-certs",
+]
+
+[[package]]
+name = "rustls-mbedtls-provider-utils"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "mbedtls",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ members = [
     "rustls-mbedpki-provider",
     "rustls-mbedtls-provider-utils",
 ]
-default-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
+default-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider", "rustls-mbedtls-provider-utils"]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,9 @@
 [workspace]
-members = ["examples","rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
+members = [
+    "examples",
+    "rustls-mbedcrypto-provider",
+    "rustls-mbedpki-provider",
+    "rustls-mbedtls-provider-utils",
+]
 default-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider"]
 resolver = "2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,5 @@ publish = false
 rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider" }
 rustls-mbedpki-provider = { path = "../rustls-mbedpki-provider" }
 env_logger = "0.10"
-# TODO: upgrade to use formal 0.22.0 or 0.22.0-* versions when availabe
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default-features = false }
+rustls = { version = "0.22.0-alpha.4", default-features = false }
 rustls-native-certs = "0.6.3"
-

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -17,6 +17,10 @@ mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
     "std",
 ] }
 log = { version = "0.4.4", optional = true }
+pki-types = { package = "rustls-pki-types", version = "0.2.1", features = [
+    "std",
+] }
+utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc
@@ -33,7 +37,6 @@ webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-featu
     "alloc",
     "std",
 ] }
-pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 webpki-roots = "0.26.0-alpha.1"
 rustls-pemfile = "2.0.0-alpha.1"
 env_logger = "0.10"

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -12,12 +12,11 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-# TODO: upgrade to use formal 0.22.0 or 0.22.0-* versions when availabe
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default-features = false }
+rustls = { version = "0.22.0-alpha.4", default-features = false }
 mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
     "std",
 ] }
-log = { version = "0.4.20", optional = true }
+log = { version = "0.4.4", optional = true }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc
@@ -27,7 +26,7 @@ mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default-features = false, features = [
+rustls = { version = "0.22.0-alpha.4", default-features = false, features = [
     "ring",
 ] }
 webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = [
@@ -36,9 +35,9 @@ webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-featu
 ] }
 pki-types = { package = "rustls-pki-types", version = "0.2.0" }
 webpki-roots = "0.26.0-alpha.1"
-rustls-pemfile = "=2.0.0-alpha.1"
+rustls-pemfile = "2.0.0-alpha.1"
 env_logger = "0.10"
-log = { version = "0.4.20" }
+log = { version = "0.4.4" }
 
 [features]
 default = ["logging", "tls12"]

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -20,6 +20,7 @@ log = { version = "0.4.4", optional = true }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", features = [
     "std",
 ] }
+webpki = { package = "rustls-webpki", version = "0.102.0-alpha.6", features = ["alloc", "std"], default-features = false }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
 
 [target.'cfg(target_env = "msvc")'.dependencies]

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -20,8 +20,13 @@ log = { version = "0.4.4", optional = true }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", features = [
     "std",
 ] }
-webpki = { package = "rustls-webpki", version = "0.102.0-alpha.6", features = ["alloc", "std"], default-features = false }
+webpki = { package = "rustls-webpki", version = "0.102.0-alpha.6", features = [
+    "alloc",
+    "std",
+], default-features = false }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
+yasna = { version = "0.3", default-features = false, features = ["bit-vec"] }
+bit-vec = "0.6.3"
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc
@@ -34,12 +39,8 @@ mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
 rustls = { version = "0.22.0-alpha.4", default-features = false, features = [
     "ring",
 ] }
-webpki = { package = "rustls-webpki", version = "0.102.0-alpha.1", default-features = false, features = [
-    "alloc",
-    "std",
-] }
-webpki-roots = "0.26.0-alpha.1"
-rustls-pemfile = "2.0.0-alpha.1"
+webpki-roots = "=0.26.0-alpha.1"
+rustls-pemfile = "=2.0.0-alpha.1"
 env_logger = "0.10"
 log = { version = "0.4.4" }
 

--- a/rustls-mbedcrypto-provider/examples/internal/bench.rs
+++ b/rustls-mbedcrypto-provider/examples/internal/bench.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use pki_types::{CertificateDer, PrivateKeyDer};
 
 use rustls::client::Resumption;
-use rustls::crypto::ring::Ticketer;
+use rustls::crypto::ring::{cipher_suite, Ticketer};
 use rustls::server::{NoServerSessionStorage, ServerSessionMemoryCache, WebPkiClientVerifier};
 use rustls::RootCertStore;
 use rustls::{ClientConfig, ClientConnection};
@@ -178,68 +178,60 @@ static ALL_BENCHMARKS: &[BenchmarkParam] = &[
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
         &rustls::version::TLS12,
     ),
     #[cfg(feature = "tls12")]
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         &rustls::version::TLS12,
     ),
     BenchmarkParam::new(
         KeyType::Rsa,
-        rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         &rustls::version::TLS13,
     ),
-    BenchmarkParam::new(
-        KeyType::Rsa,
-        rustls::cipher_suite::TLS13_AES_256_GCM_SHA384,
-        &rustls::version::TLS13,
-    ),
-    BenchmarkParam::new(
-        KeyType::Rsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
-        &rustls::version::TLS13,
-    ),
+    BenchmarkParam::new(KeyType::Rsa, cipher_suite::TLS13_AES_256_GCM_SHA384, &rustls::version::TLS13),
+    BenchmarkParam::new(KeyType::Rsa, cipher_suite::TLS13_AES_128_GCM_SHA256, &rustls::version::TLS13),
     BenchmarkParam::new(
         KeyType::Ecdsa,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
     ),
     BenchmarkParam::new(
         KeyType::Ed25519,
-        rustls::cipher_suite::TLS13_AES_128_GCM_SHA256,
+        cipher_suite::TLS13_AES_128_GCM_SHA256,
         &rustls::version::TLS13,
     ),
 ];

--- a/rustls-mbedcrypto-provider/src/hash.rs
+++ b/rustls-mbedcrypto-provider/src/hash.rs
@@ -43,6 +43,15 @@ pub(crate) static MBED_SHA_384: Algorithm = Algorithm {
     output_len: 384 / 8,
 };
 
+/// SHA-512 as specified in [FIPS 180-4].
+///
+/// [FIPS 180-4]: http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+pub(crate) static MBED_SHA_512: Algorithm = Algorithm {
+    hash_algorithm: HashAlgorithm::SHA512,
+    hash_type: mbedtls::hash::Type::Sha512,
+    output_len: 512 / 8,
+};
+
 impl hash::Hash for Hash {
     fn start(&self) -> Box<dyn hash::Context> {
         Box::new(HashContext(MbedHashContext::new(self.0)))

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -80,6 +80,8 @@ pub(crate) mod hash;
 pub(crate) mod hmac;
 pub(crate) mod kx;
 
+/// Message signing interfaces.
+pub mod signer;
 /// TLS1.2 ciphersuites implementation.
 #[cfg(feature = "tls12")]
 pub mod tls12;
@@ -136,6 +138,17 @@ impl rustls::crypto::CryptoProvider for Mbedtls {
 
     fn default_kx_groups(&self) -> &'static [&'static dyn rustls::crypto::SupportedKxGroup] {
         ALL_KX_GROUPS
+    }
+
+    fn load_private_key(
+        &self,
+        _key_der: pki_types::PrivateKeyDer<'static>,
+    ) -> Result<alloc::sync::Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
+        todo!()
+    }
+
+    fn signature_verification_algorithms(&self) -> rustls::WebPkiSupportedAlgorithms {
+        todo!()
     }
 }
 

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -146,7 +146,7 @@ impl rustls::crypto::CryptoProvider for Mbedtls {
         &self,
         key_der: pki_types::PrivateKeyDer<'static>,
     ) -> Result<alloc::sync::Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-        Ok(alloc::sync::Arc::new(MbedTlsPkSigningKey::new(&key_der)?))
+        Ok(alloc::sync::Arc::new(sign::MbedTlsPkSigningKey::new(&key_der)?))
     }
 
     fn signature_verification_algorithms(&self) -> WebPkiSupportedAlgorithms {
@@ -197,29 +197,37 @@ pub mod cipher_suite {
 static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
         signature_verify_algo::ECDSA_P256_SHA256,
+        signature_verify_algo::ECDSA_P256_SHA384,
+        signature_verify_algo::ECDSA_P384_SHA256,
         signature_verify_algo::ECDSA_P384_SHA384,
-        signature_verify_algo::RSA_PKCS1_SHA256,
-        signature_verify_algo::RSA_PKCS1_SHA384,
-        signature_verify_algo::RSA_PKCS1_SHA512,
         signature_verify_algo::RSA_PSS_SHA256,
         signature_verify_algo::RSA_PSS_SHA384,
         signature_verify_algo::RSA_PSS_SHA512,
+        signature_verify_algo::RSA_PKCS1_SHA256,
+        signature_verify_algo::RSA_PKCS1_SHA384,
+        signature_verify_algo::RSA_PKCS1_SHA512,
     ],
     mapping: &[
         (
             SignatureScheme::ECDSA_NISTP384_SHA384,
-            &[signature_verify_algo::ECDSA_P384_SHA384],
+            &[
+                signature_verify_algo::ECDSA_P384_SHA384,
+                signature_verify_algo::ECDSA_P256_SHA384,
+            ],
         ),
         (
             SignatureScheme::ECDSA_NISTP256_SHA256,
-            &[signature_verify_algo::ECDSA_P256_SHA256],
+            &[
+                signature_verify_algo::ECDSA_P256_SHA256,
+                signature_verify_algo::ECDSA_P384_SHA256,
+            ],
         ),
-        (SignatureScheme::RSA_PKCS1_SHA512, &[signature_verify_algo::RSA_PKCS1_SHA512]),
-        (SignatureScheme::RSA_PKCS1_SHA384, &[signature_verify_algo::RSA_PKCS1_SHA384]),
-        (SignatureScheme::RSA_PKCS1_SHA256, &[signature_verify_algo::RSA_PKCS1_SHA256]),
         (SignatureScheme::RSA_PSS_SHA512, &[signature_verify_algo::RSA_PSS_SHA512]),
         (SignatureScheme::RSA_PSS_SHA384, &[signature_verify_algo::RSA_PSS_SHA384]),
         (SignatureScheme::RSA_PSS_SHA256, &[signature_verify_algo::RSA_PSS_SHA256]),
+        (SignatureScheme::RSA_PKCS1_SHA512, &[signature_verify_algo::RSA_PKCS1_SHA512]),
+        (SignatureScheme::RSA_PKCS1_SHA384, &[signature_verify_algo::RSA_PKCS1_SHA384]),
+        (SignatureScheme::RSA_PKCS1_SHA256, &[signature_verify_algo::RSA_PKCS1_SHA256]),
     ],
 };
 
@@ -234,4 +242,3 @@ pub mod kx_group {
 }
 
 pub use kx::ALL_KX_GROUPS;
-use sign::MbedTlsPkSigningKey;

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -7,7 +7,6 @@ use utils::error::mbedtls_err_into_rustls_err;
 use utils::hash::{buffer_for_hash_type, rustls_signature_scheme_to_mbedtls_hash_type};
 use utils::pk::{rustls_signature_scheme_to_mbedtls_pk_options, rustls_signature_scheme_to_mbedtls_pk_type};
 
-///
 struct MbedTlsSigner(Arc<Mutex<mbedtls::pk::Pk>>, rustls::SignatureScheme);
 
 impl Debug for MbedTlsSigner {

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -115,12 +115,12 @@ impl MbedTlsPkSigningKey {
 }
 
 const RSA_SIGNATURE_SCHEME_PREFER_LIST: &[SignatureScheme] = &[
-    SignatureScheme::RSA_PSS_SHA256,
-    SignatureScheme::RSA_PSS_SHA384,
     SignatureScheme::RSA_PSS_SHA512,
-    SignatureScheme::RSA_PKCS1_SHA256,
-    SignatureScheme::RSA_PKCS1_SHA384,
+    SignatureScheme::RSA_PSS_SHA384,
+    SignatureScheme::RSA_PSS_SHA256,
     SignatureScheme::RSA_PKCS1_SHA512,
+    SignatureScheme::RSA_PKCS1_SHA384,
+    SignatureScheme::RSA_PKCS1_SHA256,
 ];
 
 impl rustls::sign::SigningKey for MbedTlsPkSigningKey {

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -172,32 +172,51 @@ fn pk_type_to_signature_algo(pk_type: mbedtls::pk::Type) -> rustls::SignatureAlg
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustls::{SignatureAlgorithm, sign::SigningKey};
+    use rustls::{sign::SigningKey, SignatureAlgorithm};
 
     #[test]
     fn test_signing_key() {
         let ec_key_pem = include_str!("../../test-ca/ecdsa/end.key");
-        let der: pki_types::PrivateKeyDer<'static> = rustls_pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(ec_key_pem.as_bytes())).next()
-        .unwrap()
-        .unwrap()
-        .into();
+        let der: pki_types::PrivateKeyDer<'static> =
+            rustls_pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(ec_key_pem.as_bytes()))
+                .next()
+                .unwrap()
+                .unwrap()
+                .into();
         let key = MbedTlsPkSigningKey::new(&der).unwrap();
         assert_eq!("MbedTlsPkSigningKey { pk: \"Arc<Mutex<mbedtls::pk::Pk>>\", pk_type: Eckey, signature_algorithm: ECDSA, ec_signature_scheme: Some(ECDSA_NISTP256_SHA256) }", format!("{:?}", key));
-        assert!(key.choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA1]).is_none());
+        assert!(key
+            .choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA1])
+            .is_none());
         let res = key.choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256]);
         assert!(res.is_some());
-        assert_eq!("Some(MbedTlsSigner(\"Arc<Mutex<mbedtls::pk::Pk>>\", ECDSA_NISTP256_SHA256))", format!("{:?}", res));
+        assert_eq!(
+            "Some(MbedTlsSigner(\"Arc<Mutex<mbedtls::pk::Pk>>\", ECDSA_NISTP256_SHA256))",
+            format!("{:?}", res)
+        );
     }
 
     #[test]
     fn test_pk_type_to_signature_algo() {
         assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::Rsa), SignatureAlgorithm::RSA);
         assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::Ecdsa), SignatureAlgorithm::ECDSA);
-        assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::RsassaPss), SignatureAlgorithm::RSA);
+        assert_eq!(
+            pk_type_to_signature_algo(mbedtls::pk::Type::RsassaPss),
+            SignatureAlgorithm::RSA
+        );
         assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::RsaAlt), SignatureAlgorithm::RSA);
         assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::Eckey), SignatureAlgorithm::ECDSA);
-        assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::EckeyDh), SignatureAlgorithm::Unknown(255));
-        assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::Custom), SignatureAlgorithm::Unknown(255));
-        assert_eq!(pk_type_to_signature_algo(mbedtls::pk::Type::None), SignatureAlgorithm::Unknown(255));
+        assert_eq!(
+            pk_type_to_signature_algo(mbedtls::pk::Type::EckeyDh),
+            SignatureAlgorithm::Unknown(255)
+        );
+        assert_eq!(
+            pk_type_to_signature_algo(mbedtls::pk::Type::Custom),
+            SignatureAlgorithm::Unknown(255)
+        );
+        assert_eq!(
+            pk_type_to_signature_algo(mbedtls::pk::Type::None),
+            SignatureAlgorithm::Unknown(255)
+        );
     }
 }

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -130,7 +130,7 @@ impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
                 // choose a rsa schema
                 for scheme in RSA_SIGNATURE_SCHEME_PREFER_LIST {
                     if offered.contains(scheme) {
-                        let signer = MbedTlsSigner(self.pk.clone(), *scheme);
+                        let signer = MbedTlsSigner(Arc::clone(&self.pk), *scheme);
                         return Some(Box::new(signer));
                     }
                 }
@@ -141,7 +141,7 @@ impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
                     .ec_signature_scheme
                     .expect("validated");
                 if offered.contains(&scheme) {
-                    let signer = MbedTlsSigner(self.pk.clone(), scheme);
+                    let signer = MbedTlsSigner(Arc::clone(&self.pk), scheme);
                     return Some(Box::new(signer));
                 }
                 None

--- a/rustls-mbedcrypto-provider/src/signature_verify_algo.rs
+++ b/rustls-mbedcrypto-provider/src/signature_verify_algo.rs
@@ -1,6 +1,6 @@
 use super::hash::Algorithm as HashAlgorithm;
 use alloc::vec;
-use mbedtls::pk::Pk;
+use mbedtls::pk::{EcGroupId, Pk};
 use pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rustls::SignatureScheme;
 use webpki::alg_id;
@@ -10,6 +10,15 @@ pub static ECDSA_P256_SHA256: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
     hash_algo: &super::hash::MBED_SHA_256,
     public_key_alg_id: alg_id::ECDSA_P256,
+    ec_group_id: Some(EcGroupId::SecP256R1),
+    signature_alg_id: alg_id::ECDSA_SHA256,
+};
+/// ECDSA signatures using the P-384 curve and SHA-256.
+pub static ECDSA_P384_SHA256: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
+    hash_algo: &super::hash::MBED_SHA_256,
+    public_key_alg_id: alg_id::ECDSA_P384,
+    ec_group_id: Some(EcGroupId::SecP384R1),
     signature_alg_id: alg_id::ECDSA_SHA256,
 };
 /// ECDSA signatures using the P-384 curve and SHA-384.
@@ -17,6 +26,15 @@ pub static ECDSA_P384_SHA384: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::ECDSA_NISTP384_SHA384,
     hash_algo: &super::hash::MBED_SHA_384,
     public_key_alg_id: alg_id::ECDSA_P384,
+    ec_group_id: Some(EcGroupId::SecP384R1),
+    signature_alg_id: alg_id::ECDSA_SHA384,
+};
+/// ECDSA signatures using the P-256 curve and SHA-384.
+pub static ECDSA_P256_SHA384: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::ECDSA_NISTP384_SHA384,
+    hash_algo: &super::hash::MBED_SHA_384,
+    public_key_alg_id: alg_id::ECDSA_P256,
+    ec_group_id: Some(EcGroupId::SecP256R1),
     signature_alg_id: alg_id::ECDSA_SHA384,
 };
 /// RSA PKCS#1 1.5 signatures using SHA-256.
@@ -24,6 +42,7 @@ pub static RSA_PKCS1_SHA256: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PKCS1_SHA256,
     hash_algo: &super::hash::MBED_SHA_256,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PKCS1_SHA256,
 };
 /// RSA PKCS#1 1.5 signatures using SHA-384.
@@ -31,6 +50,7 @@ pub static RSA_PKCS1_SHA384: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PKCS1_SHA384,
     hash_algo: &super::hash::MBED_SHA_384,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PKCS1_SHA384,
 };
 /// RSA PKCS#1 1.5 signatures using SHA-512.
@@ -38,6 +58,7 @@ pub static RSA_PKCS1_SHA512: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PKCS1_SHA512,
     hash_algo: &super::hash::MBED_SHA_512,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PKCS1_SHA512,
 };
 /// RSA PSS signatures using SHA-256 and of
@@ -48,6 +69,7 @@ pub static RSA_PSS_SHA256: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PSS_SHA256,
     hash_algo: &super::hash::MBED_SHA_256,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PSS_SHA256,
 };
 /// RSA PSS signatures using SHA-384 and of
@@ -58,6 +80,7 @@ pub static RSA_PSS_SHA384: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PSS_SHA384,
     hash_algo: &super::hash::MBED_SHA_384,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PSS_SHA384,
 };
 /// RSA PSS signatures using SHA-512 and of
@@ -68,6 +91,7 @@ pub static RSA_PSS_SHA512: &Algorithm = &Algorithm {
     signature_scheme: SignatureScheme::RSA_PSS_SHA512,
     hash_algo: &super::hash::MBED_SHA_512,
     public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    ec_group_id: None,
     signature_alg_id: alg_id::RSA_PSS_SHA512,
 };
 
@@ -77,40 +101,44 @@ pub struct Algorithm {
     signature_scheme: SignatureScheme,
     hash_algo: &'static HashAlgorithm,
     public_key_alg_id: AlgorithmIdentifier,
+    ec_group_id: Option<EcGroupId>,
     signature_alg_id: AlgorithmIdentifier,
 }
 
 impl SignatureVerificationAlgorithm for Algorithm {
     fn verify_signature(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), InvalidSignature> {
-        let mut pk = Pk::from_public_key(public_key).map_err(|e| {
-            crate::log::error!("{e}");
-            InvalidSignature
-        })?;
-        let signature_curve = utils::pk::rustls_signature_scheme_to_mbedtls_curve_id(self.signature_scheme);
-        match signature_curve {
-            mbedtls::pk::EcGroupId::None => (),
-            _ => {
-                let curves_match = pk
+        let mut pk = match self.ec_group_id {
+            None => Pk::from_public_key(public_key).map_err(|_| InvalidSignature)?,
+            Some(ec_group_id) => {
+                let spki = yasna::construct_der(|writer| {
+                    writer.write_sequence(|writer| {
+                        writer.next().write_sequence(|w| {
+                            w.next()
+                                .write_der(&self.public_key_alg_id)
+                        });
+                        writer
+                            .next()
+                            .write_bitvec(&bit_vec::BitVec::from_bytes(public_key));
+                    })
+                });
+                let ec_pk = Pk::from_public_key(&spki).map_err(|_| InvalidSignature)?;
+                let curves_match = ec_pk
                     .curve()
-                    .is_ok_and(|pk_curve| pk_curve == signature_curve);
+                    .is_ok_and(|pk_curve| pk_curve == ec_group_id);
                 if !curves_match {
                     return Err(InvalidSignature);
-                }
+                };
+                ec_pk
             }
-        }
+        };
+
         if let Some(opts) = utils::pk::rustls_signature_scheme_to_mbedtls_pk_options(self.signature_scheme) {
             pk.set_options(opts);
         }
         let mut hash = vec![0u8; self.hash_algo.output_len];
-        mbedtls::hash::Md::hash(self.hash_algo.hash_type, message, &mut hash).map_err(|e| {
-            crate::log::error!("{e}");
-            InvalidSignature
-        })?;
+        mbedtls::hash::Md::hash(self.hash_algo.hash_type, message, &mut hash).map_err(|_| InvalidSignature)?;
         pk.verify(self.hash_algo.hash_type, &hash, signature)
-            .map_err(|e| {
-                crate::log::error!("{e}");
-                InvalidSignature
-            })
+            .map_err(|_| InvalidSignature)
     }
 
     fn public_key_alg_id(&self) -> AlgorithmIdentifier {

--- a/rustls-mbedcrypto-provider/src/signature_verify_algo.rs
+++ b/rustls-mbedcrypto-provider/src/signature_verify_algo.rs
@@ -1,0 +1,114 @@
+use super::hash::Algorithm as HashAlgorithm;
+use alloc::vec;
+use mbedtls::pk::Pk;
+use pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
+use rustls::SignatureScheme;
+use webpki::alg_id;
+
+/// ECDSA signatures using the P-256 curve and SHA-256.
+pub static ECDSA_P256_SHA256: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::ECDSA_NISTP256_SHA256,
+    hash_algo: &super::hash::MBED_SHA_256,
+    public_key_alg_id: alg_id::ECDSA_P256,
+    signature_alg_id: alg_id::ECDSA_SHA256,
+};
+/// ECDSA signatures using the P-384 curve and SHA-384.
+pub static ECDSA_P384_SHA384: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::ECDSA_NISTP384_SHA384,
+    hash_algo: &super::hash::MBED_SHA_384,
+    public_key_alg_id: alg_id::ECDSA_P384,
+    signature_alg_id: alg_id::ECDSA_SHA384,
+};
+/// RSA PKCS#1 1.5 signatures using SHA-256.
+pub static RSA_PKCS1_SHA256: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PKCS1_SHA256,
+    hash_algo: &super::hash::MBED_SHA_256,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PKCS1_SHA256,
+};
+/// RSA PKCS#1 1.5 signatures using SHA-384.
+pub static RSA_PKCS1_SHA384: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PKCS1_SHA384,
+    hash_algo: &super::hash::MBED_SHA_384,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PKCS1_SHA384,
+};
+/// RSA PKCS#1 1.5 signatures using SHA-512.
+pub static RSA_PKCS1_SHA512: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PKCS1_SHA512,
+    hash_algo: &super::hash::MBED_SHA_512,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PKCS1_SHA512,
+};
+/// RSA PSS signatures using SHA-256 and of
+/// type rsaEncryption; see [RFC 4055 Section 1.2].
+///
+/// [RFC 4055 Section 1.2]: https://tools.ietf.org/html/rfc4055#section-1.2
+pub static RSA_PSS_SHA256: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PSS_SHA256,
+    hash_algo: &super::hash::MBED_SHA_256,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PSS_SHA256,
+};
+/// RSA PSS signatures using SHA-384 and of
+/// type rsaEncryption; see [RFC 4055 Section 1.2].
+///
+/// [RFC 4055 Section 1.2]: https://tools.ietf.org/html/rfc4055#section-1.2
+pub static RSA_PSS_SHA384: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PSS_SHA384,
+    hash_algo: &super::hash::MBED_SHA_384,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PSS_SHA384,
+};
+/// RSA PSS signatures using SHA-512 and of
+/// type rsaEncryption; see [RFC 4055 Section 1.2].
+///
+/// [RFC 4055 Section 1.2]: https://tools.ietf.org/html/rfc4055#section-1.2
+pub static RSA_PSS_SHA512: &Algorithm = &Algorithm {
+    signature_scheme: SignatureScheme::RSA_PSS_SHA512,
+    hash_algo: &super::hash::MBED_SHA_512,
+    public_key_alg_id: alg_id::RSA_ENCRYPTION,
+    signature_alg_id: alg_id::RSA_PSS_SHA512,
+};
+
+/// A signature verify algorithm type
+#[derive(Clone, Debug, PartialEq)]
+pub struct Algorithm {
+    signature_scheme: SignatureScheme,
+    hash_algo: &'static HashAlgorithm,
+    public_key_alg_id: AlgorithmIdentifier,
+    signature_alg_id: AlgorithmIdentifier,
+}
+
+impl SignatureVerificationAlgorithm for Algorithm {
+    fn verify_signature(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), InvalidSignature> {
+        let mut pk = Pk::from_public_key(public_key).map_err(|_| InvalidSignature)?;
+        let signature_curve = utils::pk::rustls_signature_scheme_to_mbedtls_curve_id(self.signature_scheme);
+        match signature_curve {
+            mbedtls::pk::EcGroupId::None => (),
+            _ => {
+                let curves_match = pk
+                    .curve()
+                    .is_ok_and(|pk_curve| pk_curve == signature_curve);
+                if !curves_match {
+                    return Err(InvalidSignature);
+                }
+            }
+        }
+        if let Some(opts) = utils::pk::rustls_signature_scheme_to_mbedtls_pk_options(self.signature_scheme) {
+            pk.set_options(opts);
+        }
+        let mut hash = vec![0u8; self.hash_algo.output_len];
+        mbedtls::hash::Md::hash(self.hash_algo.hash_type, message, &mut hash).map_err(|_| InvalidSignature)?;
+        pk.verify(self.hash_algo.hash_type, &hash, signature)
+            .map_err(|_| InvalidSignature)
+    }
+
+    fn public_key_alg_id(&self) -> AlgorithmIdentifier {
+        self.public_key_alg_id
+    }
+
+    fn signature_alg_id(&self) -> AlgorithmIdentifier {
+        self.signature_alg_id
+    }
+}

--- a/rustls-mbedcrypto-provider/src/signer.rs
+++ b/rustls-mbedcrypto-provider/src/signer.rs
@@ -1,0 +1,111 @@
+use alloc::vec;
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use core::fmt::Debug;
+use mbedtls::pk::ECDSA_MAX_LEN;
+use std::sync::Mutex;
+use utils::error::mbedtls_err_into_rustls_err;
+use utils::hash::{buffer_for_hash_type, rustls_signature_scheme_to_mbedtls_hash_type};
+use utils::pk::{rustls_signature_scheme_to_mbedtls_pk_options, rustls_signature_scheme_to_mbedtls_pk_type};
+
+///
+struct MbedTlsSigner(Arc<Mutex<mbedtls::pk::Pk>>, rustls::SignatureScheme);
+
+impl Debug for MbedTlsSigner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("MbedTlsSigner")
+            .field(&"Arc<Mutex<mbedtls::pk::Pk>>")
+            .field(&self.1)
+            .finish()
+    }
+}
+
+impl rustls::sign::Signer for MbedTlsSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        let hash_type = rustls_signature_scheme_to_mbedtls_hash_type(self.1);
+        let mut hash = buffer_for_hash_type(hash_type).ok_or_else(|| rustls::Error::General("unexpected hash type".into()))?;
+        let hash_size = mbedtls::hash::Md::hash(hash_type, message, &mut hash).map_err(mbedtls_err_into_rustls_err)?;
+
+        let mut pk = self
+            .0
+            .lock()
+            .expect("poisoned PK lock!");
+        if let Some(opts) = rustls_signature_scheme_to_mbedtls_pk_options(self.1) {
+            pk.set_options(opts);
+        }
+
+        fn sig_len_for_pk(pk: &mbedtls::pk::Pk) -> usize {
+            match pk.pk_type() {
+                mbedtls::pk::Type::Eckey | mbedtls::pk::Type::EckeyDh | mbedtls::pk::Type::Ecdsa => ECDSA_MAX_LEN,
+                _ => pk.len() / 8,
+            }
+        }
+        let mut sig = vec![0; sig_len_for_pk(&pk)];
+        let sig_len = pk
+            .sign(
+                hash_type,
+                &hash[..hash_size],
+                &mut sig,
+                &mut crate::rng::rng_new().ok_or(rustls::Error::FailedToGetRandomBytes)?,
+            )
+            .map_err(mbedtls_err_into_rustls_err)?;
+        sig.truncate(sig_len);
+        Ok(sig)
+    }
+
+    fn scheme(&self) -> rustls::SignatureScheme {
+        self.1
+    }
+}
+
+/// A [`SigningKey`] implemented by using [`mbedtls`]
+///
+/// [`SigningKey`]: rustls::sign::SigningKey
+pub struct MbedTlsPkSigningKey(pub Arc<Mutex<mbedtls::pk::Pk>>);
+
+impl Debug for MbedTlsPkSigningKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("MbedTlsPkSigningKey")
+            .field(&"Arc<Mutex<mbedtls::pk::Pk>>")
+            .finish()
+    }
+}
+
+impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
+    fn choose_scheme(&self, offered: &[rustls::SignatureScheme]) -> Option<Box<dyn rustls::sign::Signer>> {
+        for scheme in offered {
+            let scheme_type = rustls_signature_scheme_to_mbedtls_pk_type(scheme);
+            if let Some(scheme_type) = scheme_type {
+                if scheme_type
+                    == self
+                        .0
+                        .lock()
+                        .expect("poisoned pk lock")
+                        .pk_type()
+                {
+                    let signer = MbedTlsSigner(self.0.clone(), *scheme);
+                    return Some(Box::new(signer));
+                }
+            }
+        }
+        None
+    }
+
+    fn algorithm(&self) -> rustls::SignatureAlgorithm {
+        use rustls::SignatureAlgorithm;
+        match self
+            .0
+            .lock()
+            .expect("poisoned pk lock")
+            .pk_type()
+        {
+            mbedtls::pk::Type::Rsa => SignatureAlgorithm::RSA,
+            mbedtls::pk::Type::Ecdsa => SignatureAlgorithm::ECDSA,
+            mbedtls::pk::Type::RsassaPss => SignatureAlgorithm::RSA,
+            mbedtls::pk::Type::Eckey => SignatureAlgorithm::ECDSA,
+            mbedtls::pk::Type::RsaAlt => SignatureAlgorithm::DSA,
+            mbedtls::pk::Type::EckeyDh => SignatureAlgorithm::Anonymous,
+            mbedtls::pk::Type::Custom => SignatureAlgorithm::Anonymous,
+            mbedtls::pk::Type::None => SignatureAlgorithm::Anonymous,
+        }
+    }
+}

--- a/rustls-mbedcrypto-provider/src/tls12.rs
+++ b/rustls-mbedcrypto-provider/src/tls12.rs
@@ -10,7 +10,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use mbedtls::cipher::raw::{CipherId, CipherMode, CipherType};
 use mbedtls::cipher::{Authenticated, Cipher, Decryption, Encryption, Fresh};
-use rustls::cipher_suite::CipherSuiteCommon;
 use rustls::crypto::cipher::{
     make_tls12_aad, AeadKey, BorrowedPlainMessage, Iv, KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OpaqueMessage,
     PlainMessage, Tls12AeadAlgorithm, UnsupportedOperationError, NONCE_LEN,
@@ -20,7 +19,9 @@ use rustls::crypto::KeyExchangeAlgorithm;
 
 use super::aead::{self, Algorithm, AES128_GCM, AES256_GCM};
 use alloc::string::String;
-use rustls::{CipherSuite, ConnectionTrafficSecrets, Error, SignatureScheme, SupportedCipherSuite, Tls12CipherSuite};
+use rustls::{
+    CipherSuite, CipherSuiteCommon, ConnectionTrafficSecrets, Error, SignatureScheme, SupportedCipherSuite, Tls12CipherSuite,
+};
 
 pub(crate) const GCM_FIXED_IV_LEN: usize = 4;
 pub(crate) const GCM_EXPLICIT_NONCE_LEN: usize = 8;

--- a/rustls-mbedcrypto-provider/src/tls13.rs
+++ b/rustls-mbedcrypto-provider/src/tls13.rs
@@ -12,7 +12,6 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use mbedtls::cipher::raw::CipherType;
 use mbedtls::cipher::{Authenticated, Cipher, Decryption, Encryption, Fresh};
-use rustls::cipher_suite::CipherSuiteCommon;
 use rustls::crypto::cipher::{
     make_tls13_aad, AeadKey, BorrowedPlainMessage, Iv, MessageDecrypter, MessageEncrypter, Nonce, OpaqueMessage, PlainMessage,
     Tls13AeadAlgorithm, UnsupportedOperationError,
@@ -20,7 +19,8 @@ use rustls::crypto::cipher::{
 use rustls::crypto::tls13::HkdfUsingHmac;
 use rustls::internal::msgs::codec::Codec;
 use rustls::{
-    CipherSuite, ConnectionTrafficSecrets, ContentType, Error, ProtocolVersion, SupportedCipherSuite, Tls13CipherSuite,
+    CipherSuite, CipherSuiteCommon, ConnectionTrafficSecrets, ContentType, Error, ProtocolVersion, SupportedCipherSuite,
+    Tls13CipherSuite,
 };
 
 /// The TLS1.3 ciphersuite TLS_CHACHA20_POLY1305_SHA256

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -9,8 +9,8 @@
 #![cfg_attr(read_buf, feature(core_io_borrowed_buf))]
 //! Assorted public API tests.
 use std::cell::RefCell;
-use std::fmt;
-use std::fmt::Debug;
+use core::fmt;
+use core::fmt::Debug;
 use std::io::{self, IoSlice, Read, Write};
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -35,7 +35,7 @@ use rustls::{
 };
 use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
 use rustls::{ClientConfig, ClientConnection};
-use rustls::{ConnectionTrafficSecrets, DistinguishedName};
+use rustls::DistinguishedName;
 use rustls::{ServerConfig, ServerConnection};
 use rustls::{Stream, StreamOwned};
 
@@ -4263,6 +4263,7 @@ fn test_no_warning_logging_during_successful_sessions() {
 #[cfg(feature = "tls12")]
 #[test]
 fn test_secret_extraction_enabled() {
+    use rustls::ConnectionTrafficSecrets;
     // Normally, secret extraction would be used to configure kTLS (TLS offload
     // to the kernel). We want this test to run on any platform, though, so
     // instead we just compare secrets for equality.

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -8,9 +8,9 @@
 #![cfg_attr(read_buf, feature(read_buf))]
 #![cfg_attr(read_buf, feature(core_io_borrowed_buf))]
 //! Assorted public API tests.
-use std::cell::RefCell;
 use core::fmt;
 use core::fmt::Debug;
+use std::cell::RefCell;
 use std::io::{self, IoSlice, Read, Write};
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -28,6 +28,7 @@ use rustls::internal::msgs::enums::AlertLevel;
 use rustls::internal::msgs::handshake::{ClientExtension, HandshakePayload};
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
+use rustls::DistinguishedName;
 use rustls::SupportedCipherSuite;
 use rustls::{
     sign, AlertDescription, CertificateError, ConnectionCommon, ContentType, Error, KeyLog, PeerIncompatible, PeerMisbehaved,
@@ -35,7 +36,6 @@ use rustls::{
 };
 use rustls::{CipherSuite, ProtocolVersion, SignatureScheme};
 use rustls::{ClientConfig, ClientConnection};
-use rustls::DistinguishedName;
 use rustls::{ServerConfig, ServerConnection};
 use rustls::{Stream, StreamOwned};
 

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -202,7 +202,7 @@ where
 pub enum KeyType {
     Rsa,
     Ecdsa,
-    Ed25519,
+    // Ed25519,
 }
 
 pub static ALL_KEY_TYPES: [KeyType; 2] = [
@@ -217,7 +217,7 @@ impl KeyType {
         match self {
             Self::Rsa => bytes_for("rsa", part),
             Self::Ecdsa => bytes_for("ecdsa", part),
-            Self::Ed25519 => bytes_for("eddsa", part),
+            // Self::Ed25519 => bytes_for("eddsa", part),
         }
     }
 

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
 use webpki::extract_trust_anchor;
 
-use rustls::client::ServerCertVerifierBuilder;
+use rustls::client::{ServerCertVerifierBuilder, WebPkiServerVerifier};
 use rustls::internal::msgs::codec::Reader;
 use rustls::internal::msgs::message::{Message, OpaqueMessage, PlainMessage};
 use rustls::server::{ClientCertVerifierBuilder, WebPkiClientVerifier};
@@ -23,6 +23,9 @@ use rustls::Error;
 use rustls::RootCertStore;
 use rustls::{ClientConfig, ClientConnection};
 use rustls::{ConnectionCommon, ServerConfig, ServerConnection, SideData};
+
+pub use rustls_mbedcrypto_provider as primary_provider;
+pub use rustls_mbedcrypto_provider::MBEDTLS as PROVIDER;
 
 macro_rules! embed_files {
     (
@@ -202,7 +205,12 @@ pub enum KeyType {
     Ed25519,
 }
 
-pub static ALL_KEY_TYPES: [KeyType; 3] = [KeyType::Rsa, KeyType::Ecdsa, KeyType::Ed25519];
+pub static ALL_KEY_TYPES: [KeyType; 2] = [
+    KeyType::Rsa,
+    KeyType::Ecdsa,
+    // ! Ed25519 is not supported by mbedtls
+    // KeyType::Ed25519,
+];
 
 impl KeyType {
     fn bytes_for(&self, part: &str) -> &'static [u8] {
@@ -263,6 +271,33 @@ impl KeyType {
     }
 }
 
+pub fn server_config_builder() -> rustls::ConfigBuilder<ServerConfig, rustls::WantsCipherSuites> {
+    // ensure `ServerConfig::builder()` is covered, even though it is
+    // equivalent to `builder_with_provider(PROVIDER)`.
+    #[cfg(feature = "ring")]
+    {
+        rustls::ServerConfig::builder()
+    }
+    #[cfg(not(feature = "ring"))]
+    {
+        rustls::ServerConfig::builder_with_provider(PROVIDER)
+    }
+}
+
+pub fn client_config_builder() -> rustls::ConfigBuilder<ClientConfig, rustls::WantsCipherSuites> {
+    // ensure `ClientConfig::builder()` is covered, even though it is
+    // equivalent to `builder_with_provider(PROVIDER)`.
+    #[cfg(feature = "ring")]
+    {
+        rustls::ClientConfig::builder()
+    }
+
+    #[cfg(not(feature = "ring"))]
+    {
+        rustls::ClientConfig::builder_with_provider(PROVIDER)
+    }
+}
+
 pub fn finish_server_config(kt: KeyType, conf: rustls::ConfigBuilder<ServerConfig, rustls::WantsVerifier>) -> ServerConfig {
     conf.with_no_client_auth()
         .with_single_cert(kt.get_chain(), kt.get_key())
@@ -270,16 +305,13 @@ pub fn finish_server_config(kt: KeyType, conf: rustls::ConfigBuilder<ServerConfi
 }
 
 pub fn make_server_config(kt: KeyType) -> ServerConfig {
-    finish_server_config(
-        kt,
-        ServerConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS).with_safe_defaults(),
-    )
+    finish_server_config(kt, server_config_builder().with_safe_defaults())
 }
 
 pub fn make_server_config_with_versions(kt: KeyType, versions: &[&'static rustls::SupportedProtocolVersion]) -> ServerConfig {
     finish_server_config(
         kt,
-        ServerConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+        server_config_builder()
             .with_safe_default_cipher_suites()
             .with_safe_default_kx_groups()
             .with_protocol_versions(versions)
@@ -293,7 +325,7 @@ pub fn make_server_config_with_kx_groups(
 ) -> ServerConfig {
     finish_server_config(
         kt,
-        ServerConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+        server_config_builder()
             .with_safe_default_cipher_suites()
             .with_kx_groups(kx_groups)
             .with_safe_default_protocol_versions()
@@ -318,11 +350,11 @@ pub fn make_server_config_with_mandatory_client_auth_crls(
     kt: KeyType,
     crls: Vec<CertificateRevocationListDer<'static>>,
 ) -> ServerConfig {
-    make_server_config_with_client_verifier(kt, WebPkiClientVerifier::builder(get_client_root_store(kt)).with_crls(crls))
+    make_server_config_with_client_verifier(kt, webpki_client_verifier_builder(get_client_root_store(kt)).with_crls(crls))
 }
 
 pub fn make_server_config_with_mandatory_client_auth(kt: KeyType) -> ServerConfig {
-    make_server_config_with_client_verifier(kt, WebPkiClientVerifier::builder(get_client_root_store(kt)))
+    make_server_config_with_client_verifier(kt, webpki_client_verifier_builder(get_client_root_store(kt)))
 }
 
 pub fn make_server_config_with_optional_client_auth(
@@ -331,7 +363,7 @@ pub fn make_server_config_with_optional_client_auth(
 ) -> ServerConfig {
     make_server_config_with_client_verifier(
         kt,
-        WebPkiClientVerifier::builder(get_client_root_store(kt))
+        webpki_client_verifier_builder(get_client_root_store(kt))
             .with_crls(crls)
             .allow_unknown_revocation_status()
             .allow_unauthenticated(),
@@ -339,7 +371,7 @@ pub fn make_server_config_with_optional_client_auth(
 }
 
 pub fn make_server_config_with_client_verifier(kt: KeyType, verifier_builder: ClientCertVerifierBuilder) -> ServerConfig {
-    ServerConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+    server_config_builder()
         .with_safe_defaults()
         .with_client_cert_verifier(verifier_builder.build().unwrap())
         .with_single_cert(kt.get_chain(), kt.get_key())
@@ -372,17 +404,14 @@ pub fn finish_client_config_with_creds(
 }
 
 pub fn make_client_config(kt: KeyType) -> ClientConfig {
-    finish_client_config(
-        kt,
-        ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS).with_safe_defaults(),
-    )
+    finish_client_config(kt, client_config_builder().with_safe_defaults())
 }
 
 pub fn make_client_config_with_kx_groups(
     kt: KeyType,
     kx_groups: &[&'static dyn rustls::crypto::SupportedKxGroup],
 ) -> ClientConfig {
-    let builder = ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+    let builder = client_config_builder()
         .with_safe_default_cipher_suites()
         .with_kx_groups(kx_groups)
         .with_safe_default_protocol_versions()
@@ -391,7 +420,7 @@ pub fn make_client_config_with_kx_groups(
 }
 
 pub fn make_client_config_with_versions(kt: KeyType, versions: &[&'static rustls::SupportedProtocolVersion]) -> ClientConfig {
-    let builder = ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+    let builder = client_config_builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()
         .with_protocol_versions(versions)
@@ -400,17 +429,14 @@ pub fn make_client_config_with_versions(kt: KeyType, versions: &[&'static rustls
 }
 
 pub fn make_client_config_with_auth(kt: KeyType) -> ClientConfig {
-    finish_client_config_with_creds(
-        kt,
-        ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS).with_safe_defaults(),
-    )
+    finish_client_config_with_creds(kt, client_config_builder().with_safe_defaults())
 }
 
 pub fn make_client_config_with_versions_with_auth(
     kt: KeyType,
     versions: &[&'static rustls::SupportedProtocolVersion],
 ) -> ClientConfig {
-    let builder = ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+    let builder = client_config_builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()
         .with_protocol_versions(versions)
@@ -422,7 +448,7 @@ pub fn make_client_config_with_verifier(
     versions: &[&'static rustls::SupportedProtocolVersion],
     verifier_builder: ServerCertVerifierBuilder,
 ) -> ClientConfig {
-    ClientConfig::builder_with_provider(rustls_mbedcrypto_provider::MBEDTLS)
+    client_config_builder()
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()
         .with_protocol_versions(versions)
@@ -430,6 +456,30 @@ pub fn make_client_config_with_verifier(
         .dangerous()
         .with_custom_certificate_verifier(verifier_builder.build().unwrap())
         .with_no_client_auth()
+}
+
+pub fn webpki_client_verifier_builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {
+    #[cfg(feature = "ring")]
+    {
+        WebPkiClientVerifier::builder(roots)
+    }
+
+    #[cfg(not(feature = "ring"))]
+    {
+        WebPkiClientVerifier::builder_with_provider(roots, PROVIDER)
+    }
+}
+
+pub fn webpki_server_verifier_builder(roots: Arc<RootCertStore>) -> ServerCertVerifierBuilder {
+    #[cfg(feature = "ring")]
+    {
+        WebPkiServerVerifier::builder(roots)
+    }
+
+    #[cfg(not(feature = "ring"))]
+    {
+        WebPkiServerVerifier::builder_with_provider(roots, PROVIDER)
+    }
 }
 
 pub fn make_pair(kt: KeyType) -> (ClientConnection, ServerConnection) {

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4", default_features = false }
+rustls = { version = "0.22.0-alpha.4", default_features = false }
 mbedtls = { version = "0.12.0-alpha.2", features = [
     "x509",
     "chrono",
@@ -35,4 +35,4 @@ mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
 
 [dev-dependencies]
 rustls-pemfile = "1.0"
-rustls = { git = "https://github.com/rustls/rustls", rev = "b776a5778ad333653670c34ff9125d8ae59b6047", version = "0.22.0-alpha.4" }
+rustls = { version = "0.22.0-alpha.4" }

--- a/rustls-mbedpki-provider/src/client_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/client_cert_verifier.rs
@@ -5,18 +5,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use chrono::NaiveDateTime;
 use pki_types::{CertificateDer, UnixTime};
 use rustls::{
     server::danger::{ClientCertVerified, ClientCertVerifier},
     DistinguishedName,
 };
+use utils::error::mbedtls_err_into_rustls_err_with_error_msg;
 
 use crate::{
-    mbedtls_err_into_rustls_err, mbedtls_err_into_rustls_err_with_error_msg, rustls_cert_to_mbedtls_cert,
-    verify_certificates_active, verify_tls_signature, CertActiveCheck,
+    mbedtls_err_into_rustls_err, rustls_cert_to_mbedtls_cert, verify_certificates_active, verify_tls_signature, CertActiveCheck,
 };
 
 /// A [`rustls`] [`ClientCertVerifier`] implemented using the PKI functionality of
@@ -27,6 +29,17 @@ pub struct MbedTlsClientCertVerifier {
     root_subjects: Vec<DistinguishedName>,
     verify_callback: Option<Arc<dyn mbedtls::x509::VerifyCallback + 'static>>,
     cert_active_check: CertActiveCheck,
+}
+
+impl std::fmt::Debug for MbedTlsClientCertVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MbedTlsClientCertVerifier")
+            .field("trusted_cas", &"..")
+            .field("root_subjects", &self.root_subjects)
+            .field("verify_callback", &"..")
+            .field("cert_active_check", &self.cert_active_check)
+            .finish()
+    }
 }
 
 impl MbedTlsClientCertVerifier {

--- a/rustls-mbedpki-provider/src/client_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/client_cert_verifier.rs
@@ -212,6 +212,16 @@ mod tests {
     }
 
     #[test]
+    fn client_cert_verifier_debug() {
+        let root_ca = CertificateDer::from(include_bytes!("../test-data/rsa/ca.der").to_vec());
+        let client_cert_verifier = MbedTlsClientCertVerifier::new([&root_ca]).unwrap();
+        assert_eq!(
+            r#"MbedTlsClientCertVerifier { trusted_cas: "..", root_subjects: [DistinguishedName(301a3118301606035504030c0f706f6e79746f776e20525341204341)], verify_callback: "..", cert_active_check: CertActiveCheck { ignore_expired: false, ignore_not_active_yet: false } }"#,
+            format!("{:?}", client_cert_verifier)
+        );
+    }
+
+    #[test]
     fn connection_client_cert_verifier() {
         let client_config = ClientConfig::builder().with_safe_defaults();
         let root_ca = CertificateDer::from(include_bytes!("../test-data/rsa/ca.der").to_vec());

--- a/rustls-mbedpki-provider/src/client_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/client_cert_verifier.rs
@@ -31,8 +31,8 @@ pub struct MbedTlsClientCertVerifier {
     cert_active_check: CertActiveCheck,
 }
 
-impl std::fmt::Debug for MbedTlsClientCertVerifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MbedTlsClientCertVerifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MbedTlsClientCertVerifier")
             .field("trusted_cas", &"..")
             .field("root_subjects", &self.root_subjects)

--- a/rustls-mbedpki-provider/src/lib.rs
+++ b/rustls-mbedpki-provider/src/lib.rs
@@ -137,7 +137,7 @@ fn verify_tls_signature(
     let pk = cert.public_key_mut();
     let hash_type = utils::hash::rustls_signature_scheme_to_mbedtls_hash_type(dss.scheme);
 
-    // for tls 1.3, we need to verify the advertised curve in signaure scheme matches the public key
+    // for tls 1.3, we need to verify the advertised curve in signature scheme matches the public key
     if is_tls13 {
         let signature_curve = utils::pk::rustls_signature_scheme_to_mbedtls_curve_id(dss.scheme);
         match signature_curve {

--- a/rustls-mbedpki-provider/src/server_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/server_cert_verifier.rs
@@ -223,6 +223,16 @@ mod tests {
             .with_no_client_auth()
     }
 
+    #[test]
+    fn server_cert_verifier_debug() {
+        let root_ca = CertificateDer::from(include_bytes!("../test-data/rsa/ca.der").to_vec());
+        let server_cert_verifier = MbedTlsServerCertVerifier::new([&root_ca]).unwrap();
+        assert_eq!(
+            "MbedTlsServerCertVerifier { trusted_cas: \"..\", verify_callback: \"..\", cert_active_check: CertActiveCheck { ignore_expired: false, ignore_not_active_yet: false } }",
+            format!("{:?}", server_cert_verifier)
+        );
+    }
+
     fn test_connection_server_cert_verifier_with_invalid_certs(
         invalid_cert_chain: Vec<CertificateDer<'static>>,
     ) -> rustls::Error {

--- a/rustls-mbedpki-provider/src/server_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/server_cert_verifier.rs
@@ -30,8 +30,8 @@ pub struct MbedTlsServerCertVerifier {
     cert_active_check: CertActiveCheck,
 }
 
-impl std::fmt::Debug for MbedTlsServerCertVerifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MbedTlsServerCertVerifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MbedTlsServerCertVerifier")
             .field("trusted_cas", &"..")
             .field("verify_callback", &"..")

--- a/rustls-mbedpki-provider/src/server_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/server_cert_verifier.rs
@@ -5,18 +5,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::Arc;
-
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use chrono::NaiveDateTime;
 use pki_types::{CertificateDer, UnixTime};
 use rustls::{
     client::danger::{ServerCertVerified, ServerCertVerifier},
     ServerName,
 };
+use utils::error::mbedtls_err_into_rustls_err_with_error_msg;
 
 use crate::{
-    mbedtls_err_into_rustls_err, mbedtls_err_into_rustls_err_with_error_msg, rustls_cert_to_mbedtls_cert,
-    verify_certificates_active, verify_tls_signature, CertActiveCheck,
+    mbedtls_err_into_rustls_err, rustls_cert_to_mbedtls_cert, verify_certificates_active, verify_tls_signature, CertActiveCheck,
 };
 
 /// A [`rustls`] [`ServerCertVerifier`] implemented using the PKI functionality of
@@ -25,6 +28,16 @@ pub struct MbedTlsServerCertVerifier {
     trusted_cas: mbedtls::alloc::List<mbedtls::x509::Certificate>,
     verify_callback: Option<Arc<dyn mbedtls::x509::VerifyCallback + 'static>>,
     cert_active_check: CertActiveCheck,
+}
+
+impl std::fmt::Debug for MbedTlsServerCertVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MbedTlsServerCertVerifier")
+            .field("trusted_cas", &"..")
+            .field("verify_callback", &"..")
+            .field("cert_active_check", &self.cert_active_check)
+            .finish()
+    }
 }
 
 impl MbedTlsServerCertVerifier {

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -130,3 +130,21 @@ impl<V: ServerCertVerifier> ServerCertVerifier for VerifierWithSupportedVerifySc
         self.supported_verify_schemes.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_with_supported_verify_schemes_debug() {
+        let verifier = VerifierWithSupportedVerifySchemes {
+            verifier: "Sample Verifier".to_string(),
+            supported_verify_schemes: vec![
+                rustls::SignatureScheme::RSA_PKCS1_SHA1,
+                rustls::SignatureScheme::ECDSA_NISTP521_SHA512,
+            ],
+        };
+
+        assert_eq!("VerifierWithSupportedVerifySchemes { verifier: \"..\", supported_verify_schemes: [RSA_PKCS1_SHA1, ECDSA_NISTP521_SHA512] }",format!("{:?}", verifier));
+    }
+}

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -7,7 +7,10 @@
 
 use std::io;
 
-use core::ops::{Deref, DerefMut};
+use core::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, UnixTime};
 use rustls::{client::danger::ServerCertVerifier, ClientConnection, ConnectionCommon, ServerConnection, SideData};
@@ -79,6 +82,15 @@ pub(crate) fn do_handshake_until_error(
 pub(crate) struct VerifierWithSupportedVerifySchemes<V> {
     pub(crate) verifier: V,
     pub(crate) supported_verify_schemes: Vec<rustls::SignatureScheme>,
+}
+
+impl<V> Debug for VerifierWithSupportedVerifySchemes<V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VerifierWithSupportedVerifySchemes")
+            .field("verifier", &"..")
+            .field("supported_verify_schemes", &self.supported_verify_schemes)
+            .finish()
+    }
 }
 
 impl<V: ServerCertVerifier> ServerCertVerifier for VerifierWithSupportedVerifySchemes<V> {

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "rustls-mbedpki-provider"
+name = "rustls-mbedtls-provider-utils"
 version = "0.1.0-alpha.1"
 edition = "2021"
 license = "MPL-2.0"
-description = "Implements rustls PKI traits using mbedtls"
+description = "Utility code used in mbedtls based provider for rustls."
+homepage = "https://github.com/fortanix/rustls-mbedtls-provider"
 repository = "https://github.com/fortanix/rustls-mbedtls-provider"
 readme = "../README.md"
 authors = ["Fortanix Inc."]
@@ -11,29 +12,17 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { version = "0.22.0-alpha.4", default_features = false }
-mbedtls = { version = "0.12.0-alpha.2", features = [
-    "x509",
-    "chrono",
+rustls = { version = "0.22.0-alpha.4", default-features = false }
+mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
     "std",
-], default_features = false }
-
-x509-parser = "0.15"
-chrono = "0.4"
+] }
 pki-types = { package = "rustls-pki-types", version = "0.2.1", features = [
     "std",
 ] }
-utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
 
 [target.'cfg(target_env = "msvc")'.dependencies]
 # mbedtls need feature `time` to build when targeting msvc
 mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "x509",
-    "chrono",
     "std",
     "time",
 ] }
-
-[dev-dependencies]
-rustls-pemfile = "1.0"
-rustls = { version = "0.22.0-alpha.4" }

--- a/rustls-mbedtls-provider-utils/src/error.rs
+++ b/rustls-mbedtls-provider-utils/src/error.rs
@@ -50,7 +50,15 @@ mod tests {
             rustls::Error::InvalidCertificate(CertificateError::BadSignature)
         );
         assert_eq!(
+            mbedtls_err_into_rustls_err(mbedtls::Error::RsaVerifyFailed),
+            rustls::Error::InvalidCertificate(CertificateError::BadSignature)
+        );
+        assert_eq!(
             mbedtls_err_into_rustls_err(mbedtls::Error::X509BadInputData),
+            rustls::Error::InvalidCertificate(CertificateError::BadEncoding)
+        );
+        assert_eq!(
+            mbedtls_err_into_rustls_err(mbedtls::Error::X509CertUnknownFormat),
             rustls::Error::InvalidCertificate(CertificateError::BadEncoding)
         );
         assert_eq!(
@@ -64,6 +72,10 @@ mod tests {
         assert_eq!(
             mbedtls_err_into_rustls_err_with_error_msg(mbedtls::Error::X509InvalidSignature, ""),
             rustls::Error::InvalidCertificate(CertificateError::BadSignature)
+        );
+        assert_eq!(
+            mbedtls_err_into_rustls_err_with_error_msg(mbedtls::Error::CipherAuthFailed, ""),
+            rustls::Error::General(String::from("mbedTLS error CipherAuthFailed"))
         );
         assert_eq!(
             mbedtls_err_into_rustls_err_with_error_msg(mbedtls::Error::RsaVerifyFailed, ""),

--- a/rustls-mbedtls-provider-utils/src/error.rs
+++ b/rustls-mbedtls-provider-utils/src/error.rs
@@ -1,0 +1,39 @@
+use alloc::{format, sync::Arc};
+
+/// Converts an `mbedtls::Error` into a `rustls::Error`
+pub fn mbedtls_err_into_rustls_err(err: mbedtls::Error) -> rustls::Error {
+    mbedtls_err_into_rustls_err_with_error_msg(err, "")
+}
+
+/// Converts an `mbedtls::Error` into a `rustls::Error`; may include the provided `msg` in the
+/// returned error (e.g., if returning a `rustls::Error::General` error).
+pub fn mbedtls_err_into_rustls_err_with_error_msg(err: mbedtls::Error, msg: &str) -> rustls::Error {
+    match err {
+        mbedtls::Error::X509InvalidSignature |
+        mbedtls::Error::RsaVerifyFailed => rustls::Error::InvalidCertificate(rustls::CertificateError::BadSignature),
+
+        mbedtls::Error::X509CertUnknownFormat |
+        mbedtls::Error::X509BadInputData => rustls::Error::InvalidCertificate(rustls::CertificateError::BadEncoding),
+
+        // mbedtls::Error::X509AllocFailed |
+        mbedtls::Error::X509BufferTooSmall |
+        mbedtls::Error::X509CertVerifyFailed |
+        mbedtls::Error::X509FatalError |
+        mbedtls::Error::X509FeatureUnavailable |
+        // mbedtls::Error::X509FileIoError |
+        mbedtls::Error::X509InvalidAlg |
+        mbedtls::Error::X509InvalidDate |
+        mbedtls::Error::X509InvalidExtensions |
+        mbedtls::Error::X509InvalidFormat |
+        mbedtls::Error::X509InvalidSerial |
+        mbedtls::Error::X509InvalidVersion |
+        mbedtls::Error::X509SigMismatch |
+        mbedtls::Error::X509UnknownOid |
+        mbedtls::Error::X509UnknownSigAlg |
+        mbedtls::Error::X509UnknownVersion => rustls::Error::InvalidCertificate(rustls::CertificateError::Other(Arc::new(err))),
+
+        mbedtls::Error::X509InvalidName => rustls::Error::InvalidCertificate(rustls::CertificateError::NotValidForName),
+
+        _ => rustls::Error::General(format!("{err}{sep}{msg}", sep = if msg.is_empty() {""} else {"\n"})),
+    }
+}

--- a/rustls-mbedtls-provider-utils/src/hash.rs
+++ b/rustls-mbedtls-provider-utils/src/hash.rs
@@ -1,0 +1,47 @@
+use alloc::vec;
+use alloc::vec::Vec;
+use mbedtls::hash::Type;
+use rustls::SignatureScheme;
+
+/// Returns the size of the message digest given the hash type.
+fn hash_size_bytes(hash_type: Type) -> Option<usize> {
+    match hash_type {
+        Type::None => None,
+        Type::Md2 => Some(16),
+        Type::Md4 => Some(16),
+        Type::Md5 => Some(16),
+        Type::Sha1 => Some(20),
+        Type::Sha224 => Some(28),
+        Type::Sha256 => Some(32),
+        Type::Sha384 => Some(48),
+        Type::Sha512 => Some(64),
+        Type::Ripemd => Some(20), // this is MD_RIPEMD160
+    }
+}
+
+/// Returns the a ready to use empty [`Vec<u8>`] for the message digest with given hash type.
+pub fn buffer_for_hash_type(hash_type: Type) -> Option<Vec<u8>> {
+    let size = hash_size_bytes(hash_type)?;
+    Some(vec![0; size])
+}
+
+/// Helper function to convert rustls [`SignatureScheme`] to mbedtls [`Type`]
+pub fn rustls_signature_scheme_to_mbedtls_hash_type(signature_scheme: SignatureScheme) -> Type {
+    match signature_scheme {
+        SignatureScheme::RSA_PKCS1_SHA1 => Type::Sha1,
+        SignatureScheme::ECDSA_SHA1_Legacy => Type::Sha1,
+        SignatureScheme::RSA_PKCS1_SHA256 => Type::Sha256,
+        SignatureScheme::ECDSA_NISTP256_SHA256 => Type::Sha256,
+        SignatureScheme::RSA_PKCS1_SHA384 => Type::Sha384,
+        SignatureScheme::ECDSA_NISTP384_SHA384 => Type::Sha384,
+        SignatureScheme::RSA_PKCS1_SHA512 => Type::Sha512,
+        SignatureScheme::ECDSA_NISTP521_SHA512 => Type::Sha512,
+        SignatureScheme::RSA_PSS_SHA256 => Type::Sha256,
+        SignatureScheme::RSA_PSS_SHA384 => Type::Sha384,
+        SignatureScheme::RSA_PSS_SHA512 => Type::Sha512,
+        SignatureScheme::ED25519 => Type::None,
+        SignatureScheme::ED448 => Type::None,
+        SignatureScheme::Unknown(_) => Type::None,
+        _ => Type::None,
+    }
+}

--- a/rustls-mbedtls-provider-utils/src/hash.rs
+++ b/rustls-mbedtls-provider-utils/src/hash.rs
@@ -11,10 +11,10 @@ fn hash_size_bytes(hash_type: Type) -> Option<usize> {
         Type::Md4 => Some(16),
         Type::Md5 => Some(16),
         Type::Sha1 => Some(20),
-        Type::Sha224 => Some(28),
-        Type::Sha256 => Some(32),
-        Type::Sha384 => Some(48),
-        Type::Sha512 => Some(64),
+        Type::Sha224 => Some(224 / 8),
+        Type::Sha256 => Some(256 / 8),
+        Type::Sha384 => Some(384 / 8),
+        Type::Sha512 => Some(512 / 8),
         Type::Ripemd => Some(20), // this is MD_RIPEMD160
     }
 }

--- a/rustls-mbedtls-provider-utils/src/hash.rs
+++ b/rustls-mbedtls-provider-utils/src/hash.rs
@@ -10,12 +10,12 @@ fn hash_size_bytes(hash_type: Type) -> Option<usize> {
         Type::Md2 => Some(16),
         Type::Md4 => Some(16),
         Type::Md5 => Some(16),
-        Type::Sha1 => Some(20),
+        Type::Sha1 => Some(160 / 8),
         Type::Sha224 => Some(224 / 8),
         Type::Sha256 => Some(256 / 8),
         Type::Sha384 => Some(384 / 8),
         Type::Sha512 => Some(512 / 8),
-        Type::Ripemd => Some(20), // this is MD_RIPEMD160
+        Type::Ripemd => Some(160 / 8), // this is MD_RIPEMD160
     }
 }
 
@@ -43,5 +43,101 @@ pub fn rustls_signature_scheme_to_mbedtls_hash_type(signature_scheme: SignatureS
         SignatureScheme::ED448 => Type::None,
         SignatureScheme::Unknown(_) => Type::None,
         _ => Type::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_size_bytes() {
+        assert_eq!(hash_size_bytes(Type::None), None);
+        assert_eq!(hash_size_bytes(Type::Md2), Some(16));
+        assert_eq!(hash_size_bytes(Type::Md4), Some(16));
+        assert_eq!(hash_size_bytes(Type::Md5), Some(16));
+        assert_eq!(hash_size_bytes(Type::Sha1), Some(20));
+        assert_eq!(hash_size_bytes(Type::Sha224), Some(224 / 8));
+        assert_eq!(hash_size_bytes(Type::Sha256), Some(256 / 8));
+        assert_eq!(hash_size_bytes(Type::Sha384), Some(384 / 8));
+        assert_eq!(hash_size_bytes(Type::Sha512), Some(512 / 8));
+        assert_eq!(hash_size_bytes(Type::Ripemd), Some(20));
+        // Add more test cases if needed
+    }
+
+    #[test]
+    fn test_buffer_for_hash_type() {
+        assert_eq!(buffer_for_hash_type(Type::None), None);
+        assert_eq!(buffer_for_hash_type(Type::Md2), Some(vec![0; 16]));
+        assert_eq!(buffer_for_hash_type(Type::Md4), Some(vec![0; 16]));
+        assert_eq!(buffer_for_hash_type(Type::Md5), Some(vec![0; 16]));
+        assert_eq!(buffer_for_hash_type(Type::Sha1), Some(vec![0; 20]));
+        assert_eq!(buffer_for_hash_type(Type::Sha224), Some(vec![0; 28]));
+        assert_eq!(buffer_for_hash_type(Type::Sha256), Some(vec![0; 32]));
+        assert_eq!(buffer_for_hash_type(Type::Sha384), Some(vec![0; 48]));
+        assert_eq!(buffer_for_hash_type(Type::Sha512), Some(vec![0; 64]));
+        assert_eq!(buffer_for_hash_type(Type::Ripemd), Some(vec![0; 20]));
+        // Add more test cases if needed
+    }
+
+    #[test]
+    fn test_rustls_signature_scheme_to_mbedtls_hash_type() {
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PKCS1_SHA1),
+            Type::Sha1
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ECDSA_SHA1_Legacy),
+            Type::Sha1
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PKCS1_SHA256),
+            Type::Sha256
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ECDSA_NISTP256_SHA256),
+            Type::Sha256
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PKCS1_SHA384),
+            Type::Sha384
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ECDSA_NISTP384_SHA384),
+            Type::Sha384
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PKCS1_SHA512),
+            Type::Sha512
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ECDSA_NISTP521_SHA512),
+            Type::Sha512
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PSS_SHA256),
+            Type::Sha256
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PSS_SHA384),
+            Type::Sha384
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::RSA_PSS_SHA512),
+            Type::Sha512
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ED25519),
+            Type::None
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::ED448),
+            Type::None
+        );
+        assert_eq!(
+            rustls_signature_scheme_to_mbedtls_hash_type(SignatureScheme::Unknown(100)),
+            Type::None
+        );
+        // Add more test cases if needed
     }
 }

--- a/rustls-mbedtls-provider-utils/src/lib.rs
+++ b/rustls-mbedtls-provider-utils/src/lib.rs
@@ -32,7 +32,7 @@ extern crate alloc;
 #[cfg(not(test))]
 extern crate std;
 
-/// Utility code related to error types in [`mbedtls::error`]  and [`rustls::error`]
+/// Utility code related to error types: [`mbedtls::Error`] and [`rustls::Error`]
 pub mod error;
 /// Utility code related to [`mbedtls::hash`] types
 pub mod hash;

--- a/rustls-mbedtls-provider-utils/src/lib.rs
+++ b/rustls-mbedtls-provider-utils/src/lib.rs
@@ -1,0 +1,40 @@
+//! This crate provides common util code used in `rustls-mbedcrypto-provider` and `rustls-mbedpki-provider`
+
+// Require docs for public APIs, deny unsafe code, etc.
+#![forbid(unsafe_code, unused_must_use)]
+#![cfg_attr(not(bench), forbid(unstable_features))]
+#![deny(
+    clippy::alloc_instead_of_core,
+    clippy::clone_on_ref_ptr,
+    clippy::std_instead_of_core,
+    clippy::use_self,
+    clippy::upper_case_acronyms,
+    trivial_casts,
+    trivial_numeric_casts,
+    missing_docs,
+    unreachable_pub,
+    unused_import_braces,
+    unused_extern_crates,
+    unused_qualifications
+)]
+// Enable documentation for all features on docs.rs
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(bench, feature(test))]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+// This `extern crate` plus the `#![no_std]` attribute changes the default prelude from
+// `std::prelude` to `core::prelude`. That forces one to _explicitly_ import (`use`) everything that
+// is in `std::prelude` but not in `core::prelude`. This helps maintain no-std support as even
+// developers that are not interested in, or aware of, no-std support and / or that never run
+// `cargo build --no-default-features` locally will get errors when they rely on `std::prelude` API.
+#[cfg(not(test))]
+extern crate std;
+
+/// Utility code related to error types in [`mbedtls::error`]  and [`rustls::error`]
+pub mod error;
+/// Utility code related to [`mbedtls::hash`] types
+pub mod hash;
+/// Utility code related to [`mbedtls::pk`] types
+pub mod pk;

--- a/rustls-mbedtls-provider-utils/src/pk.rs
+++ b/rustls-mbedtls-provider-utils/src/pk.rs
@@ -147,7 +147,10 @@ mod tests {
             SignatureScheme::ED448,
             SignatureScheme::Unknown(123),
         ] {
-            assert_eq!(rustls_signature_scheme_to_mbedtls_curve_id(scheme), mbedtls::pk::EcGroupId::None);
+            assert_eq!(
+                rustls_signature_scheme_to_mbedtls_curve_id(scheme),
+                mbedtls::pk::EcGroupId::None
+            );
         }
     }
 }

--- a/rustls-mbedtls-provider-utils/src/pk.rs
+++ b/rustls-mbedtls-provider-utils/src/pk.rs
@@ -32,7 +32,7 @@ pub fn get_pk_supported_scheme(pk_type: &Type, offered: &[SignatureScheme]) -> O
             }
         }
     }
-    return None;
+    None
 }
 
 /// Helper function to get the corresponding [`rustls::SignatureAlgorithm`] of given [`mbedtls::pk::Pk`]

--- a/rustls-mbedtls-provider-utils/src/pk.rs
+++ b/rustls-mbedtls-provider-utils/src/pk.rs
@@ -1,0 +1,106 @@
+use mbedtls::pk::Type;
+use rustls::SignatureScheme;
+
+/// Helper function to convert [`SignatureScheme`] to [`Type`]
+pub fn rustls_signature_scheme_to_mbedtls_pk_type(scheme: &SignatureScheme) -> Option<Type> {
+    match scheme {
+        SignatureScheme::RSA_PKCS1_SHA1
+        | SignatureScheme::RSA_PKCS1_SHA256
+        | SignatureScheme::RSA_PKCS1_SHA384
+        | SignatureScheme::RSA_PKCS1_SHA512
+        | SignatureScheme::RSA_PSS_SHA384
+        | SignatureScheme::RSA_PSS_SHA256
+        | SignatureScheme::RSA_PSS_SHA512 => Some(Type::Rsa),
+        SignatureScheme::ECDSA_SHA1_Legacy
+        | SignatureScheme::ECDSA_NISTP256_SHA256
+        | SignatureScheme::ECDSA_NISTP384_SHA384
+        | SignatureScheme::ECDSA_NISTP521_SHA512 => Some(Type::Ecdsa),
+        SignatureScheme::ED25519 => None,
+        SignatureScheme::ED448 => None,
+        SignatureScheme::Unknown(_) => None,
+        _ => None,
+    }
+}
+
+/// Helper function to get mbedtls supported [`SignatureScheme`] from given [`SignatureScheme`] slice based on given [`Type`]
+pub fn get_pk_supported_scheme(pk_type: &Type, offered: &[SignatureScheme]) -> Option<SignatureScheme> {
+    for scheme in offered {
+        let scheme_type = rustls_signature_scheme_to_mbedtls_pk_type(scheme);
+        if let Some(scheme_type) = scheme_type {
+            if scheme_type == *pk_type {
+                return Some(*scheme);
+            }
+        }
+    }
+    return None;
+}
+
+/// Helper function to get the corresponding [`rustls::SignatureAlgorithm`] of given [`mbedtls::pk::Pk`]
+pub fn get_signature_algo_from_pk(pk: &mbedtls::pk::Pk) -> rustls::SignatureAlgorithm {
+    let pk_type = pk.pk_type();
+    match pk_type {
+        Type::Rsa | Type::RsaAlt | Type::RsassaPss => rustls::SignatureAlgorithm::RSA,
+        Type::Ecdsa => rustls::SignatureAlgorithm::ECDSA,
+        Type::Eckey | Type::EckeyDh => match pk.curve().expect("validated") {
+            // TODO: ED25519 maybe not supported yet or not supported by mbedtls
+            mbedtls::pk::EcGroupId::Curve25519 => rustls::SignatureAlgorithm::ED25519,
+            // TODO: ED448 maybe not supported yet or not supported by mbedtls
+            mbedtls::pk::EcGroupId::Curve448 => rustls::SignatureAlgorithm::ED448,
+            _ => rustls::SignatureAlgorithm::Unknown(u8::MAX),
+        },
+        _ => rustls::SignatureAlgorithm::Unknown(u8::MAX),
+    }
+}
+
+/// Helper function to convert rustls [`SignatureScheme`] to mbedtls [`mbedtls::pk::Options`]
+pub fn rustls_signature_scheme_to_mbedtls_pk_options(signature_scheme: SignatureScheme) -> Option<mbedtls::pk::Options> {
+    use mbedtls::pk::Options;
+    use mbedtls::pk::RsaPadding;
+    // reference: https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.3
+    match signature_scheme {
+        SignatureScheme::RSA_PKCS1_SHA1 => None,
+        SignatureScheme::ECDSA_SHA1_Legacy => None,
+        SignatureScheme::ECDSA_NISTP256_SHA256 => None,
+        SignatureScheme::ECDSA_NISTP384_SHA384 => None,
+        SignatureScheme::ECDSA_NISTP521_SHA512 => None,
+        SignatureScheme::RSA_PKCS1_SHA256 | SignatureScheme::RSA_PKCS1_SHA384 | SignatureScheme::RSA_PKCS1_SHA512 => {
+            Some(Options::Rsa { padding: RsaPadding::Pkcs1V15 })
+        }
+        SignatureScheme::RSA_PSS_SHA256 => {
+            Some(Options::Rsa { padding: RsaPadding::Pkcs1V21 { mgf: mbedtls::hash::Type::Sha256 } })
+        }
+        SignatureScheme::RSA_PSS_SHA384 => {
+            Some(Options::Rsa { padding: RsaPadding::Pkcs1V21 { mgf: mbedtls::hash::Type::Sha384 } })
+        }
+        SignatureScheme::RSA_PSS_SHA512 => {
+            Some(Options::Rsa { padding: RsaPadding::Pkcs1V21 { mgf: mbedtls::hash::Type::Sha512 } })
+        }
+        SignatureScheme::ED25519 => None,
+        SignatureScheme::ED448 => None,
+        SignatureScheme::Unknown(_) => None,
+        _ => None,
+    }
+}
+
+/// Helper function to convert rustls [`SignatureScheme`] to mbedtls [`mbedtls::pk::EcGroupId`]
+pub fn rustls_signature_scheme_to_mbedtls_curve_id(signature_scheme: SignatureScheme) -> mbedtls::pk::EcGroupId {
+    // reference: https://www.rfc-editor.org/rfc/rfc8446.html#section-4.2.3
+    use mbedtls::pk::EcGroupId;
+    match signature_scheme {
+        SignatureScheme::ECDSA_NISTP256_SHA256 => EcGroupId::SecP256R1,
+        SignatureScheme::ECDSA_NISTP384_SHA384 => EcGroupId::SecP384R1,
+        SignatureScheme::ECDSA_NISTP521_SHA512 => EcGroupId::SecP521R1,
+        SignatureScheme::ECDSA_SHA1_Legacy => EcGroupId::None,
+        SignatureScheme::RSA_PKCS1_SHA1 => EcGroupId::None,
+        SignatureScheme::RSA_PKCS1_SHA256 => EcGroupId::None,
+        SignatureScheme::RSA_PKCS1_SHA384 => EcGroupId::None,
+        SignatureScheme::RSA_PKCS1_SHA512 => EcGroupId::None,
+        SignatureScheme::RSA_PSS_SHA256 => EcGroupId::None,
+        SignatureScheme::RSA_PSS_SHA384 => EcGroupId::None,
+        SignatureScheme::RSA_PSS_SHA512 => EcGroupId::None,
+        SignatureScheme::ED25519 => EcGroupId::None,
+        SignatureScheme::ED448 => EcGroupId::None,
+        SignatureScheme::Unknown(_) => EcGroupId::None,
+        _ => EcGroupId::None,
+    }
+}


### PR DESCRIPTION
- Add impls for SignatureVerificationAlgorithm
- Upgrade `rustls` version to `0.22.0-alpha.4`
- Extract common functions to new crate named `rustls-mbedtls-provider-utils`