### PR TITLE
Add mbedtls based hkdf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,8 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "mbedtls"
 version = "0.12.1"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ecfbadfdbaa354a1cb85c03317ae679ef15363e15aa251ada8364fa364e6c3"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -433,7 +434,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -444,7 +446,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.4+mbedtls-2.28.3"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d7ce5f5cf8204f7d901bf98d220f54514c6a30ac0dc7cfc473d499139196d4"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,8 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80d983bdf8dc2b6e2fe808b67978047ec976147998c59126ef9faef4d5d24c7"
+version = "0.12.1"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -434,8 +433,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -446,8 +444,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.4+mbedtls-2.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7ce5f5cf8204f7d901bf98d220f54514c6a30ac0dc7cfc473d499139196d4"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"
 dependencies = [
  "bindgen",
  "cc",
@@ -1175,8 +1172,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-
-[[patch.unused]]
-name = "mbedtls"
-version = "0.12.1"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "mbedtls"
 version = "0.12.0"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -432,6 +433,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
 dependencies = [
  "cc",
  "cfg-if",
@@ -442,6 +444,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.4+mbedtls-2.28.3"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,8 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "mbedtls"
 version = "0.12.0"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80d983bdf8dc2b6e2fe808b67978047ec976147998c59126ef9faef4d5d24c7"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -433,7 +434,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -444,7 +446,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.4+mbedtls-2.28.3"
-source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/add-hkdf#e0a67bc1d9185683f700a6ab4b888a68a9b686ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d7ce5f5cf8204f7d901bf98d220f54514c6a30ac0dc7cfc473d499139196d4"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,3 +1175,8 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[patch.unused]]
+name = "mbedtls"
+version = "0.12.1"
+source = "git+https://github.com/fortanix/rust-mbedtls?branch=yx/fix-windows-build#96deb191034d8674c27cf914d0474f5122e1bbe5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.0-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228976da3acdebe818892aff63978494dc84104a8b3a250b0554f24436143a93"
+version = "0.12.0"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -434,8 +432,6 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -446,8 +442,6 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.4+mbedtls-2.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d7ce5f5cf8204f7d901bf98d220f54514c6a30ac0dc7cfc473d499139196d4"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedcrypto-provider"
-version = "0.0.1-alpha.1"
+version = "0.0.1"
 dependencies = [
  "bencher",
  "bit-vec 0.6.3",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedpki-provider"
-version = "0.1.0-alpha.1"
+version = "0.0.1"
 dependencies = [
  "chrono",
  "mbedtls",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedtls-provider-utils"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "mbedtls",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ default-members = [
 resolver = "2"
 
 [patch.crates-io]
-mbedtls = { path = "/home/yuxiang.cao/test_ws/fortanix/rust-mbedtls/mbedtls" }
+mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "yx/add-hkdf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ default-members = [
     "rustls-mbedtls-provider-utils",
 ]
 resolver = "2"
+
+[patch.crates-io]
+mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "yx/fix-windows-build" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ default-members = [
     "rustls-mbedtls-provider-utils",
 ]
 resolver = "2"
-
-[patch.crates-io]
-mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "yx/add-hkdf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ default-members = [
     "rustls-mbedtls-provider-utils",
 ]
 resolver = "2"
-
-[patch.crates-io]
-mbedtls = { git = "https://github.com/fortanix/rust-mbedtls", branch = "yx/fix-windows-build" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,12 @@ members = [
     "rustls-mbedpki-provider",
     "rustls-mbedtls-provider-utils",
 ]
-default-members = ["rustls-mbedcrypto-provider", "rustls-mbedpki-provider", "rustls-mbedtls-provider-utils"]
+default-members = [
+    "rustls-mbedcrypto-provider",
+    "rustls-mbedpki-provider",
+    "rustls-mbedtls-provider-utils",
+]
 resolver = "2"
+
+[patch.crates-io]
+mbedtls = { path = "/home/yuxiang.cao/test_ws/fortanix/rust-mbedtls/mbedtls" }

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedcrypto-provider"
-version = "0.0.1-alpha.1"
+version = "0.0.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "Mbedtls based crypto provider for rustls."
@@ -19,7 +19,7 @@ webpki = { package = "rustls-webpki", version = "0.102.0", features = [
     "alloc",
     "std",
 ], default-features = false }
-utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
+utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0" }
 yasna = { version = "0.3", default-features = false, features = ["bit-vec"] }
 bit-vec = "0.6.3"
 

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -13,9 +13,7 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default-features = false }
-mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "std",
-] }
+mbedtls = { version = "0.12.0", default-features = false, features = ["std"] }
 log = { version = "0.4.4", optional = true }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = [
     "alloc",
@@ -25,17 +23,9 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 yasna = { version = "0.3", default-features = false, features = ["bit-vec"] }
 bit-vec = "0.6.3"
 
-[target.'cfg(target_env = "msvc")'.dependencies]
-# mbedtls need feature `time` to build when targeting msvc
-mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "std",
-    "time",
-] }
 
 [dev-dependencies]
-rustls = { version = "0.22.1", default-features = false, features = [
-    "ring",
-] }
+rustls = { version = "0.22.1", default-features = false, features = ["ring"] }
 webpki-roots = "0.26.0"
 rustls-pemfile = "2"
 env_logger = "0.10"

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default-features = false }
-mbedtls = { version = "0.12.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }
 log = { version = "0.4.4", optional = true }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = [
     "alloc",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -49,6 +49,3 @@ path = "examples/internal/bench.rs"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
-[package.metadata.cargo_check_external_types]
-allowed_external_types = ["rustls_pki_types::*"]

--- a/rustls-mbedcrypto-provider/src/hmac.rs
+++ b/rustls-mbedcrypto-provider/src/hmac.rs
@@ -111,7 +111,7 @@ impl Tag {
     /// The slice can be up to [`Tag::MAX_LEN`] bytes in length.
     pub(crate) fn new(bytes: &[u8]) -> Self {
         let mut tag = Self { buf: [0u8; Self::MAX_LEN], used: bytes.len() };
-        tag.buf[..bytes.len()].copy_from_slice(bytes);
+        tag.buf[..tag.used].copy_from_slice(bytes);
         tag
     }
 

--- a/rustls-mbedcrypto-provider/src/hmac.rs
+++ b/rustls-mbedcrypto-provider/src/hmac.rs
@@ -78,12 +78,12 @@ struct MbedHmacContext {
 impl MbedHmacContext {
     /// Since the trait does not provider a way to return error, empty vector is returned when getting error from `mbedtls`.
     pub(crate) fn finish(self) -> Tag {
-        let mut out = Tag::with_capacity(self.hmac_algo.output_len);
+        let mut out = Tag::with_len(self.hmac_algo.output_len);
         match self.ctx.finish(out.as_mut()) {
             Ok(_) => out,
             Err(_err) => {
                 error!("Failed to finish hmac, mbedtls error: {:?}", _err);
-                Tag::with_capacity(0)
+                Tag::with_len(0)
             }
         }
     }
@@ -118,8 +118,8 @@ impl Tag {
     /// Build a tag with given capacity.
     ///
     /// The slice can be up to [`Tag::MAX_LEN`] bytes in length.
-    pub(crate) fn with_capacity(capacity: usize) -> Self {
-        Self { buf: [0u8; Self::MAX_LEN], used: capacity }
+    pub(crate) fn with_len(len: usize) -> Self {
+        Self { buf: [0u8; Self::MAX_LEN], used: len }
     }
 
     /// Maximum supported HMAC tag size: supports up to SHA512.

--- a/rustls-mbedcrypto-provider/src/hmac.rs
+++ b/rustls-mbedcrypto-provider/src/hmac.rs
@@ -7,8 +7,6 @@
 
 use crate::log::error;
 use alloc::boxed::Box;
-use alloc::vec;
-use alloc::vec::Vec;
 use rustls::crypto;
 
 /// HMAC using SHA-256.
@@ -17,7 +15,7 @@ pub(crate) static HMAC_SHA256: Hmac = Hmac(&super::hash::MBED_SHA_256);
 /// HMAC using SHA-384.
 pub(crate) static HMAC_SHA384: Hmac = Hmac(&super::hash::MBED_SHA_384);
 
-pub(crate) struct Hmac(&'static super::hash::Algorithm);
+pub(crate) struct Hmac(pub(crate) &'static super::hash::Algorithm);
 
 impl crypto::hmac::Hmac for Hmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
@@ -29,17 +27,24 @@ impl crypto::hmac::Hmac for Hmac {
     }
 }
 
+impl Hmac {
+    #[inline]
+    pub(crate) fn hash_algorithm(&self) -> &'static super::hash::Algorithm {
+        self.0
+    }
+}
+
 struct HmacKey(MbedHmacKey);
 
 impl crypto::hmac::Key for HmacKey {
-    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
+    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> rustls::crypto::hmac::Tag {
         let mut ctx = self.0.starts();
         ctx.update(first);
         for m in middle {
             ctx.update(m);
         }
         ctx.update(last);
-        crypto::hmac::Tag::new(&ctx.finish())
+        ctx.finish().into()
     }
 
     fn tag_len(&self) -> usize {
@@ -49,13 +54,12 @@ impl crypto::hmac::Key for HmacKey {
 
 struct MbedHmacKey {
     hmac_algo: &'static super::hash::Algorithm,
-    /// use [`crypto::hmac::Tag`] for saving key material, since they have same max size.
-    key: crypto::hmac::Tag,
+    key: Tag,
 }
 
 impl MbedHmacKey {
     pub(crate) fn new(hmac_algo: &'static super::hash::Algorithm, key: &[u8]) -> Self {
-        Self { hmac_algo, key: crypto::hmac::Tag::new(key) }
+        Self { hmac_algo, key: Tag::new(key) }
     }
 
     pub(crate) fn starts(&self) -> MbedHmacContext {
@@ -73,13 +77,13 @@ struct MbedHmacContext {
 
 impl MbedHmacContext {
     /// Since the trait does not provider a way to return error, empty vector is returned when getting error from `mbedtls`.
-    pub(crate) fn finish(self) -> Vec<u8> {
-        let mut out = vec![0u8; self.hmac_algo.output_len];
-        match self.ctx.finish(&mut out) {
+    pub(crate) fn finish(self) -> Tag {
+        let mut out = Tag::with_capacity(self.hmac_algo.output_len);
+        match self.ctx.finish(out.as_mut()) {
             Ok(_) => out,
             Err(_err) => {
                 error!("Failed to finish hmac, mbedtls error: {:?}", _err);
-                vec![]
+                Tag::with_capacity(0)
             }
         }
     }
@@ -91,5 +95,57 @@ impl MbedHmacContext {
                 error!("Failed to update hmac, mbedtls error: {:?}", _err);
             }
         }
+    }
+}
+
+/// A HMAC tag, stored as a value.
+#[derive(Clone)]
+pub(crate) struct Tag {
+    buf: [u8; Self::MAX_LEN],
+    used: usize,
+}
+
+impl Tag {
+    /// Build a tag by copying a byte slice.
+    ///
+    /// The slice can be up to [`Tag::MAX_LEN`] bytes in length.
+    pub(crate) fn new(bytes: &[u8]) -> Self {
+        let mut tag = Self { buf: [0u8; Self::MAX_LEN], used: bytes.len() };
+        tag.buf[..bytes.len()].copy_from_slice(bytes);
+        tag
+    }
+
+    /// Build a tag with given capacity.
+    ///
+    /// The slice can be up to [`Tag::MAX_LEN`] bytes in length.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self { buf: [0u8; Self::MAX_LEN], used: capacity }
+    }
+
+    /// Maximum supported HMAC tag size: supports up to SHA512.
+    pub(crate) const MAX_LEN: usize = 64;
+}
+
+impl Drop for Tag {
+    fn drop(&mut self) {
+        mbedtls::zeroize(&mut self.buf)
+    }
+}
+
+impl AsRef<[u8]> for Tag {
+    fn as_ref(&self) -> &[u8] {
+        &self.buf[..self.used]
+    }
+}
+
+impl AsMut<[u8]> for Tag {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.buf[..self.used]
+    }
+}
+
+impl From<Tag> for rustls::crypto::hmac::Tag {
+    fn from(val: Tag) -> Self {
+        Self::new(&val.buf[..val.used])
     }
 }

--- a/rustls-mbedcrypto-provider/src/tls13.rs
+++ b/rustls-mbedcrypto-provider/src/tls13.rs
@@ -255,12 +255,11 @@ impl HkdfExpander for MbedHkdfHmacExpander {
             .flat_map(|&slice| slice)
             .cloned()
             .collect();
-        let _ = mbedtls::hash::Hkdf::hkdf_expand(self.hash_alg.hash_type, self.prf.as_ref(), &info, tag.as_mut()).map_err(
-            |_err| {
+        let _ =
+            mbedtls::hash::Hkdf::hkdf_expand(self.hash_alg.hash_type, self.prf.as_ref(), &info, tag.as_mut()).map_err(|_err| {
                 error!("MbedHkdfExpander::expand_slice got mbedtls error: {:?}", _err);
                 OutputLengthError
-            },
-        );
+            });
         OkmBlock::new(tag.as_ref())
     }
 

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default_features = false }
-mbedtls = { version = "0.12.0-alpha.2", features = [
+mbedtls = { version = "0.12.0", features = [
     "x509",
     "chrono",
     "std",
@@ -22,16 +22,6 @@ x509-parser = "0.15"
 chrono = "0.4"
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
 
-[target.'cfg(target_env = "msvc")'.dependencies]
-# mbedtls need feature `time` to build when targeting msvc
-mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "x509",
-    "chrono",
-    "std",
-    "time",
-] }
-
 [dev-dependencies]
 rustls-pemfile = "2"
 rustls = { version = "0.22.1" }
-

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedpki-provider"
-version = "0.1.0-alpha.1"
+version = "0.0.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "Implements rustls PKI traits using mbedtls"
@@ -20,7 +20,7 @@ mbedtls = { version = "0.12.0", features = [
 
 x509-parser = "0.15"
 chrono = "0.4"
-utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0-alpha.1" }
+utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.1.0" }
 
 [dev-dependencies]
 rustls-pemfile = "2"

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default_features = false }
-mbedtls = { version = "0.12.0", features = [
+mbedtls = { version = "0.12.1", features = [
     "x509",
     "chrono",
     "std",

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedtls-provider-utils"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "Utility code used in mbedtls based provider for rustls."

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -13,13 +13,4 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default-features = false }
-mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "std",
-] }
-
-[target.'cfg(target_env = "msvc")'.dependencies]
-# mbedtls need feature `time` to build when targeting msvc
-mbedtls = { version = "0.12.0-alpha.2", default-features = false, features = [
-    "std",
-    "time",
-] }
+mbedtls = { version = "0.12.0", default-features = false, features = ["std"] }

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "2"
 
 [dependencies]
 rustls = { version = "0.22.1", default-features = false }
-mbedtls = { version = "0.12.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
## Description

This PR adds HKDF implementation by using `mbedtls` functions.

From benchmarks, there is ~7% performance improvement:
```shell
$ RUSTFLAGS="--cfg=bench" cargo +nightly bench hkdf

running 2 tests
test tls13::benchmarks::bench_mbedtls_hkdf              ... bench:       3,275 ns/iter (+/- 43)
test tls13::benchmarks::bench_rustls_hkdf_mbedtls_hmac  ... bench:       3,050 ns/iter (+/- 44)
```

This PR also:
- Upgrades `mbedtls` to `0.12.1`
- Bumps all crates version to `0.0.1`

## Note
- [x] This needs to wait for https://github.com/fortanix/rust-mbedtls/pull/336 to merged first.
- [x] Then update the `mbedtls` version used here.

This PR will fix #7 