### PR TITLE
Implement FFDHE support in mbedcrypto-provider

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     paths-ignore:
       - '*.md'
       - 'LICENSE'
+    branches:
+        - master
+        - ffdhe
   merge_group:
   schedule:
     - cron: '30 13 * * *'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - '*.md'
       - 'LICENSE'
-    branches:
-      - master
   merge_group:
   schedule:
     - cron: '30 13 * * *'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.0-alpha.0"
-source = "git+https://github.com/fortanix/rustls?branch=ffdhe#b575fc15a3b7805e83437267254eb8ce928b60fb"
+source = "git+https://github.com/fortanix/rustls?branch=ffdhe#67453664d21310470348e2d8874d54bfd0e9fe03"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,9 +666,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b63262c9fcac8659abfaa96cac103d28166d3ff3eaf8f412e19f3ae9e5a48"
+version = "0.23.0-alpha.0"
+source = "git+https://github.com/fortanix/rustls?branch=ffdhe#b575fc15a3b7805e83437267254eb8ce928b60fb"
 dependencies = [
  "log",
  "ring",
@@ -717,6 +716,7 @@ dependencies = [
  "rustls-mbedpki-provider",
  "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider", features = ["tls12"] }
 rustls-mbedpki-provider = { path = "../rustls-mbedpki-provider" }
 env_logger = "0.10"
-rustls = { version = "0.22.1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe", default-features = false }
 rustls-native-certs = "0.7.0"
+rustls-pki-types = "1"
 rustls-pemfile = "2"

--- a/examples/src/bin/ffdhe-server.rs
+++ b/examples/src/bin/ffdhe-server.rs
@@ -1,0 +1,64 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::io::Write;
+use std::sync::Arc;
+
+use rustls::crypto::CryptoProvider;
+use rustls_mbedcrypto_provider::{kx_group, mbedtls_crypto_provider};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+
+/// Get a certificate chain from the contents of a pem file
+fn get_chain(bytes: &[u8]) -> Vec<CertificateDer> {
+    rustls_pemfile::certs(&mut std::io::BufReader::new(bytes))
+        .map(Result::unwrap)
+        .map(CertificateDer::from)
+        .collect()
+}
+
+/// Get a private key from the contents of a pem file
+fn get_key(bytes: &[u8]) -> PrivateKeyDer {
+    let value = rustls_pemfile::pkcs8_private_keys(&mut std::io::BufReader::new(bytes))
+        .next()
+        .unwrap()
+        .unwrap();
+    PrivateKeyDer::from(value)
+}
+
+fn main() {
+    env_logger::init();
+
+    let cert = get_chain(include_bytes!("../../../rustls-mbedpki-provider/test-data/rsa/end.fullchain").as_ref());
+    let key = get_key(include_bytes!("../../../rustls-mbedpki-provider/test-data/rsa/end.key").as_ref());
+    let config = rustls::ServerConfig::builder_with_provider(
+        CryptoProvider {
+            cipher_suites: vec![
+                rustls_mbedcrypto_provider::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+                rustls_mbedcrypto_provider::cipher_suite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+            ],
+            kx_groups: vec![kx_group::FFDHE2048],
+            ..mbedtls_crypto_provider()
+        }
+        .into(),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_no_client_auth()
+    .with_single_cert(cert, key)
+    .unwrap();
+
+    let config = Arc::new(config);
+
+    let server = std::net::TcpListener::bind(("localhost", 8888)).unwrap();
+    loop {
+        let mut sock = server.accept().unwrap();
+        let mut conn = rustls::ServerConnection::new(config.clone()).unwrap();
+        let mut tls = rustls::Stream::new(&mut conn, &mut sock.0);
+        println!("write res: {:?}", tls.write_all(b"Hi there!"));
+        let _ = tls.flush();
+    }
+}

--- a/examples/src/bin/ffdhe.rs
+++ b/examples/src/bin/ffdhe.rs
@@ -1,0 +1,123 @@
+/* Copyright (c) Fortanix, Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::io::{stdout, Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+
+use rustls::client::danger::{ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::CryptoProvider;
+use rustls_mbedcrypto_provider::kx_group;
+use rustls_mbedcrypto_provider::mbedtls_crypto_provider;
+use rustls_mbedpki_provider::MbedTlsServerCertVerifier;
+
+fn main() {
+    env_logger::init();
+
+    let check_server_cert = true;
+    let server = "browserleaks.com";
+    let path = "/";
+    let port = 443;
+
+    let server_cert_verifier: Arc<dyn ServerCertVerifier> = if check_server_cert {
+        let root_certs: Vec<_> = rustls_native_certs::load_native_certs()
+            .expect("could not load platform certs")
+            .into_iter()
+            .map(|cert| cert.into())
+            .collect();
+        Arc::new(MbedTlsServerCertVerifier::new(&root_certs).unwrap())
+    } else {
+        Arc::new(NoopServerCertVerifier)
+    };
+
+    let config = rustls::ClientConfig::builder_with_provider(
+        CryptoProvider {
+            cipher_suites: vec![
+                rustls_mbedcrypto_provider::cipher_suite::TLS13_AES_256_GCM_SHA384,
+                rustls_mbedcrypto_provider::cipher_suite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+                rustls_mbedcrypto_provider::cipher_suite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+                rustls_mbedcrypto_provider::cipher_suite::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+            ],
+            kx_groups: vec![kx_group::FFDHE2048, kx_group::FFDHE3072, kx_group::FFDHE4096],
+            ..mbedtls_crypto_provider()
+        }
+        .into(),
+    )
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(server_cert_verifier)
+    .with_no_client_auth();
+
+    let server_name = server.try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
+    let mut sock = TcpStream::connect((server, port)).unwrap();
+    conn.complete_io(&mut sock).unwrap();
+    println!("tls connection established");
+    let mut tls = rustls::Stream::new(&mut conn, &mut sock);
+    tls.write_all(
+        format!(
+            "HEAD {path} HTTP/1.1\r\n \
+            Host: {server}\r\n \
+            Connection: close\r\n \
+            Accept-Encoding: identity\r\n \
+            \r\n"
+        )
+        .as_bytes(),
+    )
+    .unwrap();
+    tls.flush().unwrap();
+
+    let ciphersuite = tls
+        .conn
+        .negotiated_cipher_suite()
+        .unwrap();
+    println!("Current ciphersuite: {:?}", ciphersuite.suite());
+
+    let mut plaintext = Vec::new();
+    tls.read_to_end(&mut plaintext).unwrap();
+    println!("Response:");
+    stdout().write_all(&plaintext).unwrap();
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct NoopServerCertVerifier;
+impl ServerCertVerifier for NoopServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls_pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls_pki_types::CertificateDer<'_>],
+        _server_name: &rustls_pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls_mbedpki_provider::SUPPORTED_SIGNATURE_SCHEMA.to_vec()
+    }
+}

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { version = "0.22.1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }
 log = { version = "0.4.4", optional = true }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = [
@@ -25,7 +25,9 @@ bit-vec = "0.6.3"
 
 
 [dev-dependencies]
-rustls = { version = "0.22.1", default-features = false, features = ["ring"] }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe", default-features = false, features = [
+    "ring",
+] }
 webpki-roots = "0.26.0"
 rustls-pemfile = "2"
 env_logger = "0.10"

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -170,16 +170,11 @@ impl ActiveKeyExchange for KeyExchange {
     }
 }
 
+#[derive(Debug)]
 struct DheKxGroup {
     name: NamedGroup,
     group: ffdhe_groups::FfdheGroup<'static>,
     priv_key_len: usize,
-}
-
-impl fmt::Debug for DheKxGroup {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:?}", self.name)
-    }
 }
 
 impl SupportedKxGroup for DheKxGroup {

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -15,11 +15,15 @@ use alloc::fmt;
 use alloc::format;
 use alloc::vec::Vec;
 use crypto::SupportedKxGroup;
+use mbedtls::bignum::Mpi;
+use mbedtls::rng::Random;
 use mbedtls::{
     ecp::EcPoint,
     pk::{EcGroup, Pk as PkMbed},
 };
 use rustls::crypto;
+use rustls::crypto::ActiveKeyExchange;
+use rustls::ffdhe_groups;
 use rustls::Error;
 use rustls::NamedGroup;
 /// A key-exchange group supported by *mbedtls*.
@@ -41,7 +45,7 @@ impl fmt::Debug for KxGroup {
 }
 
 impl SupportedKxGroup for KxGroup {
-    fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, Error> {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let priv_key = generate_ec_key(self.agreement_algorithm.group_id)?;
 
         Ok(Box::new(KeyExchange {
@@ -78,8 +82,33 @@ pub static SECP384R1: &dyn SupportedKxGroup =
 pub static SECP521R1: &dyn SupportedKxGroup =
     &KxGroup { name: NamedGroup::secp521r1, agreement_algorithm: &agreement::ECDH_P521 };
 
+/// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
+pub static FFDHE2048: &dyn SupportedKxGroup =
+    &DheKxGroup { name: NamedGroup::FFDHE2048, group: ffdhe_groups::FFDHE2048, priv_key_len: 36 };
+
+/// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
+pub static FFDHE3072: &dyn SupportedKxGroup =
+    &DheKxGroup { name: NamedGroup::FFDHE3072, group: ffdhe_groups::FFDHE3072, priv_key_len: 40 };
+
+/// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
+pub static FFDHE4096: &dyn SupportedKxGroup =
+    &DheKxGroup { name: NamedGroup::FFDHE4096, group: ffdhe_groups::FFDHE4096, priv_key_len: 48 };
+
+/// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
+pub static FFDHE6144: &dyn SupportedKxGroup =
+    &DheKxGroup { name: NamedGroup::FFDHE6144, group: ffdhe_groups::FFDHE6144, priv_key_len: 56 };
+
+/// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
+pub static FFDHE8192: &dyn SupportedKxGroup =
+    &DheKxGroup { name: NamedGroup::FFDHE8192, group: ffdhe_groups::FFDHE8192, priv_key_len: 64 };
+
 /// A list of all the key exchange groups supported by mbedtls.
-pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[X25519, SECP256R1, SECP384R1, SECP521R1];
+pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[
+    // ECDHE groups:
+    X25519, SECP256R1, SECP384R1, SECP521R1, // fmt
+    // (FF)DHE groups:
+    FFDHE2048, FFDHE3072, FFDHE4096, FFDHE6144, FFDHE8192,
+];
 
 /// An in-progress key exchange.  This has the algorithm,
 /// our private key, and our public key.
@@ -102,7 +131,7 @@ impl KeyExchange {
     }
 }
 
-impl crypto::ActiveKeyExchange for KeyExchange {
+impl ActiveKeyExchange for KeyExchange {
     /// Completes the key exchange, given the peer's public key.
     fn complete(mut self: Box<Self>, peer_public_key: &[u8]) -> Result<crypto::SharedSecret, Error> {
         let group_id = self.agreement_algorithm.group_id;
@@ -135,6 +164,101 @@ impl crypto::ActiveKeyExchange for KeyExchange {
     }
 
     /// Return the group being used.
+    fn group(&self) -> NamedGroup {
+        self.name
+    }
+}
+
+struct DheKxGroup {
+    name: NamedGroup,
+    group: ffdhe_groups::FfdheGroup<'static>,
+    priv_key_len: usize,
+}
+
+impl fmt::Debug for DheKxGroup {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self.name)
+    }
+}
+
+impl SupportedKxGroup for DheKxGroup {
+    fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
+        let g = mbedtls::bignum::Mpi::from_binary(self.group.g).map_err(mbedtls_err_to_rustls_error)?;
+        let p = mbedtls::bignum::Mpi::from_binary(self.group.p).map_err(mbedtls_err_to_rustls_error)?;
+
+        let mut rng = super::rng::rng_new().ok_or(rustls::crypto::GetRandomFailed)?;
+        let mut x = vec![0; self.priv_key_len];
+        rng.random(&mut x)
+            .map_err(|_| rustls::crypto::GetRandomFailed)?;
+        let x = mbedtls::bignum::Mpi::from_binary(&x)
+            .map_err(|e| Error::General(format!("failed to make Bignum from random bytes: {}", e)))?;
+
+        let x_pub = g
+            .mod_exp(&x, &p)
+            .map_err(mbedtls_err_to_rustls_error)?;
+
+        Ok(Box::new(DheActiveKeyExchange {
+            name: self.name,
+            group: self.group,
+            x: x.to_binary()
+                .map_err(mbedtls_err_to_rustls_error)?,
+            x_pub: x_pub
+                .to_binary()
+                .map_err(mbedtls_err_to_rustls_error)?,
+        }))
+    }
+
+    fn name(&self) -> NamedGroup {
+        self.name
+    }
+}
+
+struct DheActiveKeyExchange {
+    name: NamedGroup,
+    group: ffdhe_groups::FfdheGroup<'static>,
+    x: Vec<u8>,
+    x_pub: Vec<u8>,
+}
+
+impl ActiveKeyExchange for DheActiveKeyExchange {
+    fn complete(self: Box<Self>, peer_pub_key: &[u8]) -> Result<crypto::SharedSecret, Error> {
+        let y_pub = Mpi::from_binary(peer_pub_key).map_err(mbedtls_err_to_rustls_error)?;
+
+        let x = Mpi::from_binary(&self.x).map_err(mbedtls_err_to_rustls_error)?;
+        let p = Mpi::from_binary(self.group.p).map_err(mbedtls_err_to_rustls_error)?;
+
+        let one = Mpi::new(1).map_err(mbedtls_err_to_rustls_error)?;
+
+        let mut p_minus_one = p;
+        p_minus_one -= &one;
+
+        // https://www.rfc-editor.org/rfc/rfc7919.html#section-5.1:
+        // Peers MUST validate each other's public key Y [...] by ensuring that 1 < Y < p-1.
+        if !(one < y_pub && y_pub < p_minus_one) {
+            return Err(Error::General(
+                "Invalid DHE key exchange public key received; pub key must be in range (1, p-1)".into(),
+            ));
+        }
+
+        p_minus_one += &one;
+        let p = p_minus_one;
+
+        let secret = y_pub
+            .mod_exp(&x, &p)
+            .map_err(mbedtls_err_to_rustls_error)?;
+
+        Ok(crypto::SharedSecret::from(
+            secret
+                .to_binary()
+                .map_err(mbedtls_err_to_rustls_error)?
+                .as_ref(),
+        ))
+    }
+
+    fn pub_key(&self) -> &[u8] {
+        &self.x_pub
+    }
+
     fn group(&self) -> NamedGroup {
         self.name
     }

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -190,12 +190,19 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    #[cfg(feature = "tls12")]
+    tls12::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    #[cfg(feature = "tls12")]
+    tls12::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    #[cfg(feature = "tls12")]
+    tls12::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
 /// All defined cipher suites supported by *mbedtls* appear in this module.
 pub mod cipher_suite {
     #[cfg(feature = "tls12")]
     pub use super::tls12::{
+        TLS_DHE_RSA_WITH_AES_128_GCM_SHA256, TLS_DHE_RSA_WITH_AES_256_GCM_SHA384, TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
         TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
         TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
@@ -246,6 +253,12 @@ static SUPPORTED_SIG_ALGS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms
 ///
 /// [`ALL_KX_GROUPS`] is provided as an array of all of these values.
 pub mod kx_group {
+    pub use super::kx::FFDHE2048;
+    pub use super::kx::FFDHE3072;
+    pub use super::kx::FFDHE4096;
+    pub use super::kx::FFDHE6144;
+    pub use super::kx::FFDHE8192;
+
     pub use super::kx::SECP256R1;
     pub use super::kx::SECP384R1;
     pub use super::kx::SECP521R1;

--- a/rustls-mbedcrypto-provider/src/tls12.rs
+++ b/rustls-mbedcrypto-provider/src/tls12.rs
@@ -111,6 +111,48 @@ pub static TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = Suppo
     prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
 });
 
+/// The TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+pub static TLS_DHE_RSA_WITH_AES_128_GCM_SHA256: SupportedCipherSuite = SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: 1 << 23,
+        integrity_limit: 1 << 52,
+    },
+    kx: KeyExchangeAlgorithm::DHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES128_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+});
+
+/// The TLS1.2 ciphersuite TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+pub static TLS_DHE_RSA_WITH_AES_256_GCM_SHA384: SupportedCipherSuite = SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+        hash_provider: &super::hash::SHA384,
+        confidentiality_limit: 1 << 23,
+        integrity_limit: 1 << 52,
+    },
+    kx: KeyExchangeAlgorithm::DHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &AES256_GCM,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA384),
+});
+
+/// The TLS1.2 ciphersuite TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+pub static TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256: SupportedCipherSuite = SupportedCipherSuite::Tls12(&Tls12CipherSuite {
+    common: CipherSuiteCommon {
+        suite: CipherSuite::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        hash_provider: &super::hash::SHA256,
+        confidentiality_limit: u64::MAX,
+        integrity_limit: 1 << 36,
+    },
+    kx: KeyExchangeAlgorithm::DHE,
+    sign: TLS12_RSA_SCHEMES,
+    aead_alg: &ChaCha20Poly1305,
+    prf_provider: &PrfUsingHmac(&super::hmac::HMAC_SHA256),
+});
+
 static TLS12_ECDSA_SCHEMES: &[SignatureScheme] = &[
     SignatureScheme::ED25519,
     SignatureScheme::ECDSA_NISTP521_SHA512,

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -2435,6 +2435,24 @@ static TEST_CIPHERSUITES: &[(&rustls::SupportedProtocolVersion, KeyType, CipherS
         KeyType::Rsa,
         CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
     ),
+    #[cfg(feature = "tls12")]
+    (
+        &rustls::version::TLS12,
+        KeyType::Rsa,
+        CipherSuite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
+    ),
+    #[cfg(feature = "tls12")]
+    (
+        &rustls::version::TLS12,
+        KeyType::Rsa,
+        CipherSuite::TLS_DHE_RSA_WITH_AES_256_GCM_SHA384,
+    ),
+    #[cfg(feature = "tls12")]
+    (
+        &rustls::version::TLS12,
+        KeyType::Rsa,
+        CipherSuite::TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+    ),
 ];
 
 #[test]

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -4064,3 +4064,65 @@ fn test_explicit_provider_selection() {
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
     do_handshake(&mut client, &mut server);
 }
+
+#[cfg(feature = "tls12")]
+#[test]
+fn test_ffdhe_bad_pub_key_is_rejected() {
+    use primary_provider::cipher_suite;
+    use rustls::crypto::{ActiveKeyExchange, SupportedKxGroup};
+
+    #[derive(Debug, Clone)]
+    struct BadFfdheKx(&'static [u8]);
+    impl SupportedKxGroup for BadFfdheKx {
+        fn start(&self) -> Result<Box<dyn rustls::crypto::ActiveKeyExchange>, Error> {
+            Ok(Box::new(self.clone()))
+        }
+        fn name(&self) -> rustls::NamedGroup {
+            rustls::NamedGroup::FFDHE2048
+        }
+    }
+    impl ActiveKeyExchange for BadFfdheKx {
+        fn complete(self: Box<Self>, _peer_pub_key: &[u8]) -> Result<rustls::crypto::SharedSecret, Error> {
+            unimplemented!()
+        }
+        fn pub_key(&self) -> &[u8] {
+            self.0
+        }
+        fn group(&self) -> rustls::NamedGroup {
+            rustls::NamedGroup::FFDHE2048
+        }
+    }
+
+    const TEST_CASES: [BadFfdheKx; 2] = [BadFfdheKx(&[1]), BadFfdheKx(rustls::ffdhe_groups::FFDHE2048.p)];
+
+    for bad_ffdhe_kx in &TEST_CASES {
+        println!("bad ffdhe pub key: {:?}", bad_ffdhe_kx.0);
+        let client_config = finish_client_config(
+            KeyType::Rsa,
+            rustls::ClientConfig::builder_with_provider(mbedtls_crypto_provider().into())
+                .with_safe_default_protocol_versions()
+                .unwrap(),
+        );
+        let server_config = finish_server_config(
+            KeyType::Rsa,
+            rustls::ServerConfig::builder_with_provider(
+                CryptoProvider {
+                    cipher_suites: vec![cipher_suite::TLS_DHE_RSA_WITH_AES_128_GCM_SHA256],
+                    kx_groups: vec![bad_ffdhe_kx],
+                    ..mbedtls_crypto_provider()
+                }
+                .into(),
+            )
+            .with_safe_default_protocol_versions()
+            .unwrap(),
+        );
+
+        let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
+        let handshake_res = do_handshake_until_error(&mut client, &mut server);
+
+        let ErrorFromPeer::Client(client_err) = handshake_res.as_ref().unwrap_err() else {
+            panic!("Unexpected error from server: {:?}", handshake_res)
+        };
+        assert!(dbg!(client_err.to_string()).contains("pub key must be in range (1, p-1)"));
+    }
+}

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -329,7 +329,9 @@ pub fn make_server_config_with_kx_groups(
     finish_server_config(
         kt,
         ServerConfig::builder_with_provider(
-            CryptoProvider { kx_groups: kx_groups.to_vec(), ..mbedtls_crypto_provider() }.into(),
+            CryptoProvider { kx_groups: kx_groups.to_vec(), ..mbedtls_crypto_provider() }
+                .with_cipher_suites_without_matching_kx_removed()
+                .into(),
         )
         .with_safe_default_protocol_versions()
         .unwrap(),
@@ -421,7 +423,9 @@ pub fn make_client_config_with_kx_groups(
     kx_groups: &[&'static dyn rustls::crypto::SupportedKxGroup],
 ) -> ClientConfig {
     let builder = ClientConfig::builder_with_provider(
-        CryptoProvider { kx_groups: kx_groups.to_vec(), ..mbedtls_crypto_provider() }.into(),
+        CryptoProvider { kx_groups: kx_groups.to_vec(), ..mbedtls_crypto_provider() }
+            .with_cipher_suites_without_matching_kx_removed()
+            .into(),
     )
     .with_safe_default_protocol_versions()
     .unwrap();

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { version = "0.22.1", default_features = false }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe", default_features = false }
 mbedtls = { version = "0.12.1", features = [
     "x509",
     "chrono",
@@ -24,6 +24,6 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 
 [dev-dependencies]
 rustls-pemfile = "2"
-rustls = { version = "0.22.1" }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe" }
 # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 mbedtls = { version = "0.12.1", features = ["time"], default_features = false }

--- a/rustls-mbedpki-provider/src/server_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/server_cert_verifier.rs
@@ -286,7 +286,7 @@ mod tests {
             (SignatureScheme::RSA_PSS_SHA256, &TLS13),
         ];
         for (scheme, protocol) in test_cases {
-            test_connection_server_cert_verifier(vec![scheme], &[&protocol]);
+            test_connection_server_cert_verifier(vec![scheme], &[protocol]);
         }
     }
 

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { version = "0.22.1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", branch = "ffdhe", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
This PR adds support for FFDHE key exchange (RFC 7919) to mbedcrypto-provider, and retargets rustls dependency to a branch with ffdhe support.