### PR TITLE
Avoid sending empty root hints list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.0-alpha.0"
-source = "git+https://github.com/fortanix/rustls?rev=1f9441aba2fe859e98084c164bacc334a5140689#1f9441aba2fe859e98084c164bacc334a5140689"
+source = "git+https://github.com/fortanix/rustls?tag=ffdhe-r2#8ce66b9e34737bc21af1f1dc3fb053921e2aba83"
 dependencies = [
  "log",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.23.0-alpha.0"
-source = "git+https://github.com/fortanix/rustls?tag=ffdhe-r1#9e63ed3b7d5ce0419b7a0b83cadb6a815cf6bfef"
+source = "git+https://github.com/fortanix/rustls?rev=1f9441aba2fe859e98084c164bacc334a5140689#1f9441aba2fe859e98084c164bacc334a5140689"
 dependencies = [
  "log",
  "ring",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider", features = ["tls12"] }
 rustls-mbedpki-provider = { path = "../rustls-mbedpki-provider" }
 env_logger = "0.10"
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
 rustls-native-certs = "0.7.0"
 rustls-pki-types = "1"
 rustls-pemfile = "2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 rustls-mbedcrypto-provider = { path = "../rustls-mbedcrypto-provider", features = ["tls12"] }
 rustls-mbedpki-provider = { path = "../rustls-mbedpki-provider" }
 env_logger = "0.10"
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2", default-features = false }
 rustls-native-certs = "0.7.0"
 rustls-pki-types = "1"
 rustls-pemfile = "2"

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }
 log = { version = "0.4.4", optional = true }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = [
@@ -25,7 +25,7 @@ bit-vec = "0.6.3"
 
 
 [dev-dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1", default-features = false, features = [
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false, features = [
     "ring",
 ] }
 webpki-roots = "0.26.0"

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }
 log = { version = "0.4.4", optional = true }
 webpki = { package = "rustls-webpki", version = "0.102.0", features = [
@@ -25,7 +25,7 @@ bit-vec = "0.6.3"
 
 
 [dev-dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false, features = [
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2", default-features = false, features = [
     "ring",
 ] }
 webpki-roots = "0.26.0"

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default_features = false }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2", default_features = false }
 mbedtls = { version = "0.12.1", features = [
     "x509",
     "chrono",
@@ -24,6 +24,6 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 
 [dev-dependencies]
 rustls-pemfile = "2"
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689" }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2" }
 # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 mbedtls = { version = "0.12.1", features = ["time"], default_features = false }

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1", default_features = false }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default_features = false }
 mbedtls = { version = "0.12.1", features = [
     "x509",
     "chrono",
@@ -24,6 +24,6 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 
 [dev-dependencies]
 rustls-pemfile = "2"
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1" }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689" }
 # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 mbedtls = { version = "0.12.1", features = ["time"], default_features = false }

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r1", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["network-programming", "cryptography"]
 resolver = "2"
 
 [dependencies]
-rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe-r2", default-features = false }
 mbedtls = { version = "0.12.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
This PR need to wait for https://github.com/fortanix/rustls/pull/5 to be merged.

Then update the `rustls` to use new `tag` again.