### PR TITLE
Add support of specify RNG for crypto algorithms

### DIFF
--- a/rustls-mbedcrypto-provider/src/agreement.rs
+++ b/rustls-mbedcrypto-provider/src/agreement.rs
@@ -8,7 +8,7 @@
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
 
 /// An ECDH key agreement algorithm.
-pub(crate) struct Algorithm {
+pub struct Algorithm {
     pub(crate) group_id: EcGroupId,
     pub(crate) public_key_len: usize,
     pub(crate) max_signature_len: usize,

--- a/rustls-mbedcrypto-provider/src/agreement.rs
+++ b/rustls-mbedcrypto-provider/src/agreement.rs
@@ -8,7 +8,7 @@
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
 
 /// An ECDH key agreement algorithm.
-pub struct Algorithm {
+pub(crate) struct Algorithm {
     pub(crate) group_id: EcGroupId,
     pub(crate) public_key_len: usize,
     pub(crate) max_signature_len: usize,

--- a/rustls-mbedcrypto-provider/src/hmac.rs
+++ b/rustls-mbedcrypto-provider/src/hmac.rs
@@ -38,7 +38,7 @@ impl Hmac {
 struct HmacKey(MbedHmacKey);
 
 impl crypto::hmac::Key for HmacKey {
-    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> rustls::crypto::hmac::Tag {
+    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
         let mut ctx = self.0.starts();
         ctx.update(first);
         for m in middle {
@@ -142,7 +142,7 @@ impl AsMut<[u8]> for Tag {
     }
 }
 
-impl From<Tag> for rustls::crypto::hmac::Tag {
+impl From<Tag> for crypto::hmac::Tag {
     fn from(val: Tag) -> Self {
         Self::new(&val.buf[..val.used])
     }

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -264,7 +264,6 @@ pub struct DheKxGroup<T: RngCallback> {
     pub rng_provider_fn: fn() -> Option<T>,
 }
 
-
 impl<T: RngCallback> fmt::Debug for DheKxGroup<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DheKxGroup")

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -38,7 +38,7 @@ pub struct KxGroup<T: RngCallback> {
     /// The IANA "TLS Supported Groups" name of the group
     pub name: NamedGroup,
 
-    /// The corresponding [`agreement::Algorithm`]
+    /// The corresponding agreement algorithm
     pub agreement_algorithm: &'static agreement::Algorithm,
 
     /// Function to provider a RNG

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -198,7 +198,7 @@ struct KeyExchange<T: RngCallback> {
     priv_key: PkMbed,
     /// Public key in binary format [`EcPoint`] without compression
     pub_key: OnceLock<Vec<u8>>,
-    /// Function to provider a RNG
+    /// Callback to produce RNGs when needed
     rng_provider: fn() -> Option<T>,
 }
 

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -41,8 +41,8 @@ pub struct KxGroup<T: RngCallback> {
     /// The corresponding agreement algorithm
     pub agreement_algorithm: &'static agreement::Algorithm,
 
-    /// Function to provider a RNG
-    pub rng_provider_fn: fn() -> Option<T>,
+    /// Callback to produce RNGs when needed
+    pub rng_provider: fn() -> Option<T>,
 }
 
 impl<T: RngCallback> fmt::Debug for KxGroup<T> {
@@ -53,7 +53,7 @@ impl<T: RngCallback> fmt::Debug for KxGroup<T> {
 
 impl<T: RngCallback + 'static> SupportedKxGroup for KxGroup<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-        let mut rng = (self.rng_provider_fn)().ok_or(Error::FailedToGetRandomBytes)?;
+        let mut rng = (self.rng_provider)().ok_or(Error::FailedToGetRandomBytes)?;
 
         #[allow(unused_mut)]
         let mut priv_key = generate_ec_key(self.agreement_algorithm.group_id, &mut rng)?;
@@ -72,7 +72,7 @@ impl<T: RngCallback + 'static> SupportedKxGroup for KxGroup<T> {
             agreement_algorithm: self.agreement_algorithm,
             priv_key,
             pub_key: OnceLock::new(),
-            rng_provider_fn: self.rng_provider_fn,
+            rng_provider: self.rng_provider,
         }))
     }
 
@@ -93,7 +93,7 @@ pub static X25519: &dyn SupportedKxGroup = X25519_KX_GROUP;
 pub static X25519_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
     name: NamedGroup::X25519,
     agreement_algorithm: &agreement::X25519,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
@@ -102,7 +102,7 @@ pub static SECP256R1: &dyn SupportedKxGroup = SECP256R1_KX_GROUP;
 pub static SECP256R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
     name: NamedGroup::secp256r1,
     agreement_algorithm: &agreement::ECDH_P256,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
@@ -111,7 +111,7 @@ pub static SECP384R1: &dyn SupportedKxGroup = SECP384R1_KX_GROUP;
 pub static SECP384R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
     name: NamedGroup::secp384r1,
     agreement_algorithm: &agreement::ECDH_P384,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp521r1 (aka NIST-P521)
@@ -120,7 +120,7 @@ pub static SECP521R1: &dyn SupportedKxGroup = SECP521R1_KX_GROUP;
 pub static SECP521R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
     name: NamedGroup::secp521r1,
     agreement_algorithm: &agreement::ECDH_P521,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
@@ -130,7 +130,7 @@ pub static FFDHE2048_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
     named_group: NamedGroup::FFDHE2048,
     group: ffdhe_groups::FFDHE2048,
     priv_key_len: 36,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
@@ -140,7 +140,7 @@ pub static FFDHE3072_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
     named_group: NamedGroup::FFDHE3072,
     group: ffdhe_groups::FFDHE3072,
     priv_key_len: 40,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
@@ -150,7 +150,7 @@ pub static FFDHE4096_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
     named_group: NamedGroup::FFDHE4096,
     group: ffdhe_groups::FFDHE4096,
     priv_key_len: 48,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
@@ -160,7 +160,7 @@ pub static FFDHE6144_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
     named_group: NamedGroup::FFDHE6144,
     group: ffdhe_groups::FFDHE6144,
     priv_key_len: 56,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
@@ -170,7 +170,7 @@ pub static FFDHE8192_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
     named_group: NamedGroup::FFDHE8192,
     group: ffdhe_groups::FFDHE8192,
     priv_key_len: 64,
-    rng_provider_fn: crate::rng::rng_new,
+    rng_provider: crate::rng::rng_new,
 };
 
 /// A list of all the key exchange groups supported by mbedtls.
@@ -192,7 +192,7 @@ struct KeyExchange<T: RngCallback> {
     /// Public key in binary format [`EcPoint`] without compression
     pub_key: OnceLock<Vec<u8>>,
     /// Function to provider a RNG
-    rng_provider_fn: fn() -> Option<T>,
+    rng_provider: fn() -> Option<T>,
 }
 
 impl<T: RngCallback> KeyExchange<T> {
@@ -215,7 +215,7 @@ impl<T: RngCallback> ActiveKeyExchange for KeyExchange<T> {
 
         let peer_pk = parse_peer_public_key(group_id, peer_public_key).map_err(mbedtls_err_to_rustls_error)?;
 
-        let mut rng = (self.rng_provider_fn)().ok_or(crypto::GetRandomFailed)?;
+        let mut rng = (self.rng_provider)().ok_or(crypto::GetRandomFailed)?;
 
         // Only run fips check on applied NamedGroups
         #[cfg(feature = "fips")]
@@ -260,8 +260,8 @@ pub struct DheKxGroup<T: RngCallback> {
     pub group: FfdheGroup<'static>,
     /// Private key length
     pub priv_key_len: usize,
-    /// Function to provider a RNG
-    pub rng_provider_fn: fn() -> Option<T>,
+    /// Callback to produce RNGs when needed
+    pub rng_provider: fn() -> Option<T>,
 }
 
 impl<T: RngCallback> fmt::Debug for DheKxGroup<T> {
@@ -270,7 +270,7 @@ impl<T: RngCallback> fmt::Debug for DheKxGroup<T> {
             .field("named_group", &self.named_group)
             .field("group", &self.group)
             .field("priv_key_len", &self.priv_key_len)
-            .field("rng_provider_fn", &self.rng_provider_fn)
+            .field("rng_provider", &self.rng_provider)
             .finish()
     }
 }
@@ -280,7 +280,7 @@ impl<T: RngCallback> SupportedKxGroup for DheKxGroup<T> {
         let g = Mpi::from_binary(self.group.g).map_err(mbedtls_err_to_rustls_error)?;
         let p = Mpi::from_binary(self.group.p).map_err(mbedtls_err_to_rustls_error)?;
 
-        let mut rng = (self.rng_provider_fn)().ok_or(crypto::GetRandomFailed)?;
+        let mut rng = (self.rng_provider)().ok_or(crypto::GetRandomFailed)?;
         let mut x = vec![0; self.priv_key_len];
         rng.random(&mut x)
             .map_err(|_| crypto::GetRandomFailed)?;

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -431,8 +431,9 @@ mod benchmarks {
 
     #[bench]
     fn bench_ecdh_p256_gen_private_key(b: &mut test::Bencher) {
+        let mut rng = crate::rng::rng_new().unwrap();
         b.iter(|| {
-            test::black_box(super::generate_ec_key(mbedtls::pk::EcGroupId::SecP256R1).unwrap());
+            test::black_box(super::generate_ec_key(mbedtls::pk::EcGroupId::SecP256R1, &mut rng).unwrap());
         });
     }
 

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -53,7 +53,7 @@ impl<T: RngCallback> fmt::Debug for KxGroup<T> {
 
 impl<T: RngCallback + 'static> SupportedKxGroup for KxGroup<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-        let mut rng = (self.rng_provider_fn)().ok_or(rustls::Error::FailedToGetRandomBytes)?;
+        let mut rng = (self.rng_provider_fn)().ok_or(Error::FailedToGetRandomBytes)?;
 
         #[allow(unused_mut)]
         let mut priv_key = generate_ec_key(self.agreement_algorithm.group_id, &mut rng)?;
@@ -281,10 +281,10 @@ impl<T: RngCallback> SupportedKxGroup for DheKxGroup<T> {
         let g = Mpi::from_binary(self.group.g).map_err(mbedtls_err_to_rustls_error)?;
         let p = Mpi::from_binary(self.group.p).map_err(mbedtls_err_to_rustls_error)?;
 
-        let mut rng = (self.rng_provider_fn)().ok_or(rustls::crypto::GetRandomFailed)?;
+        let mut rng = (self.rng_provider_fn)().ok_or(crypto::GetRandomFailed)?;
         let mut x = vec![0; self.priv_key_len];
         rng.random(&mut x)
-            .map_err(|_| rustls::crypto::GetRandomFailed)?;
+            .map_err(|_| crypto::GetRandomFailed)?;
         let x = Mpi::from_binary(&x).map_err(|e| Error::General(format!("failed to make Bignum from random bytes: {}", e)))?;
         let x_pub = g
             .mod_exp(&x, &p)

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -90,7 +90,7 @@ impl<T: RngCallback> MbedTlsPkSigningKey<T> {
     /// Make a new [`MbedTlsPkSigningKey`] from a DER encoding.
     pub fn new(der: &pki_types::PrivateKeyDer<'_>, rng_provider_fn: fn() -> Option<T>) -> Result<Self, rustls::Error> {
         let pk = mbedtls::pk::Pk::from_private_key(der.secret_der(), None)
-            .map_err(|err| rustls::Error::Other(rustls::OtherError(alloc::sync::Arc::new(err))))?;
+            .map_err(|err| rustls::Error::Other(rustls::OtherError(Arc::new(err))))?;
         Self::from_pk(pk, rng_provider_fn)
     }
 
@@ -103,7 +103,7 @@ impl<T: RngCallback> MbedTlsPkSigningKey<T> {
             Some(
                 match pk
                     .curve()
-                    .map_err(|err| rustls::Error::Other(rustls::OtherError(alloc::sync::Arc::new(err))))?
+                    .map_err(|err| rustls::Error::Other(rustls::OtherError(Arc::new(err))))?
                 {
                     EcGroupId::SecP256R1 => SignatureScheme::ECDSA_NISTP256_SHA256,
                     EcGroupId::SecP384R1 => SignatureScheme::ECDSA_NISTP384_SHA384,
@@ -119,12 +119,12 @@ impl<T: RngCallback> MbedTlsPkSigningKey<T> {
             None
         };
         Ok(Self {
-            pk: alloc::sync::Arc::new(std::sync::Mutex::new(pk)),
+            pk: Arc::new(Mutex::new(pk)),
             pk_type,
             signature_algorithm,
             ec_signature_scheme,
             rsa_scheme_prefer_order_list: DEFAULT_RSA_SIGNATURE_SCHEME_PREFER_LIST,
-            rng_provider_fn: rng_provider_fn,
+            rng_provider_fn,
         })
     }
 

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -3,34 +3,39 @@ use alloc::vec;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
+use mbedtls::rng::RngCallback;
 use rustls::{pki_types, SignatureScheme};
 use std::sync::Mutex;
 use utils::error::mbedtls_err_into_rustls_err;
 use utils::hash::{buffer_for_hash_type, rustls_signature_scheme_to_mbedtls_hash_type};
 use utils::pk::{get_signature_schema_from_offered, pk_type_to_signature_algo, rustls_signature_scheme_to_mbedtls_pk_options};
 
-struct MbedTlsSigner(Arc<Mutex<mbedtls::pk::Pk>>, SignatureScheme);
+struct MbedTlsSigner<T: RngCallback> {
+    pk: Arc<Mutex<mbedtls::pk::Pk>>,
+    signature_scheme: SignatureScheme,
+    rng_provider_fn: fn() -> Option<T>,
+}
 
-impl Debug for MbedTlsSigner {
+impl<T: RngCallback> Debug for MbedTlsSigner<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("MbedTlsSigner")
             .field(&"Arc<Mutex<mbedtls::pk::Pk>>")
-            .field(&self.1)
+            .field(&self.signature_scheme)
             .finish()
     }
 }
 
-impl rustls::sign::Signer for MbedTlsSigner {
+impl<T: RngCallback> rustls::sign::Signer for MbedTlsSigner<T> {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
-        let hash_type = rustls_signature_scheme_to_mbedtls_hash_type(self.1);
+        let hash_type = rustls_signature_scheme_to_mbedtls_hash_type(self.signature_scheme);
         let mut hash = buffer_for_hash_type(hash_type).ok_or_else(|| rustls::Error::General("unexpected hash type".into()))?;
         let hash_size = mbedtls::hash::Md::hash(hash_type, message, &mut hash).map_err(mbedtls_err_into_rustls_err)?;
 
         let mut pk = self
-            .0
+            .pk
             .lock()
             .expect("poisoned PK lock!");
-        if let Some(opts) = rustls_signature_scheme_to_mbedtls_pk_options(self.1) {
+        if let Some(opts) = rustls_signature_scheme_to_mbedtls_pk_options(self.signature_scheme) {
             pk.set_options(opts);
         }
 
@@ -46,7 +51,7 @@ impl rustls::sign::Signer for MbedTlsSigner {
                 hash_type,
                 &hash[..hash_size],
                 &mut sig,
-                &mut crate::rng::rng_new().ok_or(rustls::Error::FailedToGetRandomBytes)?,
+                &mut (self.rng_provider_fn)().ok_or(rustls::Error::FailedToGetRandomBytes)?,
             )
             .map_err(mbedtls_err_into_rustls_err)?;
         sig.truncate(sig_len);
@@ -54,22 +59,23 @@ impl rustls::sign::Signer for MbedTlsSigner {
     }
 
     fn scheme(&self) -> SignatureScheme {
-        self.1
+        self.signature_scheme
     }
 }
 
 /// A [`SigningKey`] implemented by using [`mbedtls`]
 ///
 /// [`SigningKey`]: rustls::sign::SigningKey
-pub struct MbedTlsPkSigningKey {
+pub struct MbedTlsPkSigningKey<T: RngCallback> {
     pk: Arc<Mutex<mbedtls::pk::Pk>>,
     pk_type: mbedtls::pk::Type,
     signature_algorithm: rustls::SignatureAlgorithm,
     ec_signature_scheme: Option<SignatureScheme>,
     rsa_scheme_prefer_order_list: &'static [SignatureScheme],
+    rng_provider_fn: fn() -> Option<T>,
 }
 
-impl Debug for MbedTlsPkSigningKey {
+impl<T: RngCallback> Debug for MbedTlsPkSigningKey<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MbedTlsPkSigningKey")
             .field("pk", &"Arc<Mutex<mbedtls::pk::Pk>>")
@@ -80,16 +86,16 @@ impl Debug for MbedTlsPkSigningKey {
     }
 }
 
-impl MbedTlsPkSigningKey {
+impl<T: RngCallback> MbedTlsPkSigningKey<T> {
     /// Make a new [`MbedTlsPkSigningKey`] from a DER encoding.
-    pub fn new(der: &pki_types::PrivateKeyDer<'_>) -> Result<Self, rustls::Error> {
+    pub fn new(der: &pki_types::PrivateKeyDer<'_>, rng_provider_fn: fn() -> Option<T>) -> Result<Self, rustls::Error> {
         let pk = mbedtls::pk::Pk::from_private_key(der.secret_der(), None)
             .map_err(|err| rustls::Error::Other(rustls::OtherError(alloc::sync::Arc::new(err))))?;
-        Self::from_pk(pk)
+        Self::from_pk(pk, rng_provider_fn)
     }
 
     /// Make a new [`MbedTlsPkSigningKey`] from a [`mbedtls::pk::Pk`].
-    pub fn from_pk(pk: mbedtls::pk::Pk) -> Result<Self, rustls::Error> {
+    pub fn from_pk(pk: mbedtls::pk::Pk, rng_provider_fn: fn() -> Option<T>) -> Result<Self, rustls::Error> {
         let pk_type = pk.pk_type();
         let signature_algorithm = pk_type_to_signature_algo(pk_type)
             .ok_or(rustls::Error::General(String::from("MbedTlsPkSigningKey: invalid pk type")))?;
@@ -118,6 +124,7 @@ impl MbedTlsPkSigningKey {
             signature_algorithm,
             ec_signature_scheme,
             rsa_scheme_prefer_order_list: DEFAULT_RSA_SIGNATURE_SCHEME_PREFER_LIST,
+            rng_provider_fn: rng_provider_fn,
         })
     }
 
@@ -137,7 +144,7 @@ pub const DEFAULT_RSA_SIGNATURE_SCHEME_PREFER_LIST: &[SignatureScheme] = &[
     SignatureScheme::RSA_PKCS1_SHA256,
 ];
 
-impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
+impl<T: RngCallback + 'static> rustls::sign::SigningKey for MbedTlsPkSigningKey<T> {
     fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn rustls::sign::Signer>> {
         let scheme = get_signature_schema_from_offered(
             self.pk_type,
@@ -145,7 +152,11 @@ impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
             self.ec_signature_scheme,
             self.rsa_scheme_prefer_order_list,
         )?;
-        let signer = MbedTlsSigner(Arc::clone(&self.pk), scheme);
+        let signer = MbedTlsSigner {
+            pk: Arc::clone(&self.pk),
+            signature_scheme: scheme,
+            rng_provider_fn: self.rng_provider_fn,
+        };
         Some(Box::new(signer))
     }
 
@@ -168,7 +179,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .into();
-        let key = MbedTlsPkSigningKey::new(&der).unwrap();
+        let key = MbedTlsPkSigningKey::new(&der, crate::rng::rng_new).unwrap();
         assert_eq!("MbedTlsPkSigningKey { pk: \"Arc<Mutex<mbedtls::pk::Pk>>\", pk_type: Eckey, signature_algorithm: ECDSA, ec_signature_scheme: Some(ECDSA_NISTP256_SHA256) }", format!("{:?}", key));
         assert!(key
             .choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA1])

--- a/rustls-mbedcrypto-provider/src/tls12.rs
+++ b/rustls-mbedcrypto-provider/src/tls12.rs
@@ -278,7 +278,7 @@ impl MessageDecrypter for GcmMessageDecrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::DecryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::DecryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
         if plain_len > MAX_FRAGMENT_LEN {
@@ -316,7 +316,7 @@ impl MessageEncrypter for GcmMessageEncrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::EncryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::EncryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
         payload.extend(tag);
@@ -385,7 +385,7 @@ impl MessageDecrypter for ChaCha20Poly1305MessageDecrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::DecryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::DecryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
 
@@ -425,7 +425,7 @@ impl MessageEncrypter for ChaCha20Poly1305MessageEncrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::EncryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::EncryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
         payload.extend(tag);

--- a/rustls-mbedcrypto-provider/src/tls13.rs
+++ b/rustls-mbedcrypto-provider/src/tls13.rs
@@ -134,7 +134,7 @@ impl MessageEncrypter for Tls13MessageEncrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::EncryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::EncryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
         payload.extend(tag);
@@ -186,7 +186,7 @@ impl MessageDecrypter for Tls13MessageDecrypter {
                 mbedtls::Error::CcmAuthFailed
                 | mbedtls::Error::ChachapolyAuthFailed
                 | mbedtls::Error::CipherAuthFailed
-                | mbedtls::Error::GcmAuthFailed => rustls::Error::DecryptError,
+                | mbedtls::Error::GcmAuthFailed => Error::DecryptError,
                 _ => mbedtls_err_to_rustls_error(err),
             })?;
         payload.truncate(plain_len);

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use primary_provider::rng::rng_new;
 use primary_provider::sign::MbedTlsPkSigningKey as RsaSigningKey;
 use primary_provider::{mbedtls_crypto_provider, MbedtlsSecureRandom};
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption};
@@ -2128,7 +2129,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 fn sni_resolver_works() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
     resolver
         .add("localhost", sign::CertifiedKey::new(kt.get_chain(), signing_key.clone()))
@@ -2158,7 +2159,7 @@ fn sni_resolver_works() {
 fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2179,7 +2180,7 @@ fn sni_resolver_rejects_wrong_names() {
 fn sni_resolver_lower_cases_configured_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2202,7 +2203,7 @@ fn sni_resolver_lower_cases_queried_names() {
     // actually, the handshake parser does this, but the effect is the same.
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2224,7 +2225,7 @@ fn sni_resolver_lower_cases_queried_names() {
 fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::sync::Arc;
 
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, ServerName};
@@ -116,8 +116,8 @@ embed_files! {
 }
 
 pub fn transfer(
-    left: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    right: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;
@@ -145,7 +145,7 @@ pub fn transfer(
     total
 }
 
-pub fn transfer_eof(conn: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>)) {
+pub fn transfer_eof(conn: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>) {
     let empty_buf = [0u8; 0];
     let empty_cursor: &mut dyn io::Read = &mut &empty_buf[..];
     let sz = conn.read_tls(empty_cursor).unwrap();
@@ -514,8 +514,8 @@ pub fn make_pair_for_arc_configs(
 }
 
 pub fn do_handshake(
-    client: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    server: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    client: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    server: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> (usize, usize) {
     let (mut to_client, mut to_server) = (0, 0);
     while server.is_handshaking() || client.is_handshaking() {

--- a/rustls-mbedpki-provider/src/client_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/client_cert_verifier.rs
@@ -334,7 +334,7 @@ mod tests {
 
         let verifier = MbedTlsClientCertVerifier::new(trusted_cas.iter()).unwrap();
 
-        let now = SystemTime::from(chrono::DateTime::parse_from_rfc3339("2023-11-26T12:00:00+00:00").unwrap());
+        let now = SystemTime::from(DateTime::parse_from_rfc3339("2023-11-26T12:00:00+00:00").unwrap());
         let now = UnixTime::since_unix_epoch(
             now.duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap(),

--- a/rustls-mbedpki-provider/src/lib.rs
+++ b/rustls-mbedpki-provider/src/lib.rs
@@ -77,15 +77,15 @@ pub struct CertActiveCheck {
 
 /// All supported signature schemas
 pub const SUPPORTED_SIGNATURE_SCHEMA: [SignatureScheme; 9] = [
-    rustls::SignatureScheme::RSA_PSS_SHA512,
-    rustls::SignatureScheme::RSA_PSS_SHA384,
-    rustls::SignatureScheme::RSA_PSS_SHA256,
-    rustls::SignatureScheme::RSA_PKCS1_SHA512,
-    rustls::SignatureScheme::RSA_PKCS1_SHA384,
-    rustls::SignatureScheme::RSA_PKCS1_SHA256,
-    rustls::SignatureScheme::RSA_PSS_SHA512,
-    rustls::SignatureScheme::RSA_PSS_SHA384,
-    rustls::SignatureScheme::RSA_PSS_SHA256,
+    SignatureScheme::RSA_PSS_SHA512,
+    SignatureScheme::RSA_PSS_SHA384,
+    SignatureScheme::RSA_PSS_SHA256,
+    SignatureScheme::RSA_PKCS1_SHA512,
+    SignatureScheme::RSA_PKCS1_SHA384,
+    SignatureScheme::RSA_PKCS1_SHA256,
+    SignatureScheme::RSA_PSS_SHA512,
+    SignatureScheme::RSA_PSS_SHA384,
+    SignatureScheme::RSA_PSS_SHA256,
 ];
 
 /// Helper function to convert a [`mbedtls::x509::InvalidTimeError`] to a [`rustls::Error`]

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -7,10 +7,7 @@
 
 use std::io;
 
-use core::{
-    fmt::Debug,
-    ops::DerefMut,
-};
+use core::{fmt::Debug, ops::DerefMut};
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::{client::danger::ServerCertVerifier, ClientConnection, ConnectionCommon, ServerConnection, SideData};
@@ -35,7 +32,7 @@ pub(crate) fn get_key(bytes: &[u8]) -> PrivateKeyDer {
 // Copied from rustls repo
 pub(crate) fn transfer(
     left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
-    right: &mut impl DerefMut <Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -9,7 +9,7 @@ use std::io;
 
 use core::{
     fmt::Debug,
-    ops::{Deref, DerefMut},
+    ops::DerefMut,
 };
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
@@ -34,8 +34,8 @@ pub(crate) fn get_key(bytes: &[u8]) -> PrivateKeyDer {
 
 // Copied from rustls repo
 pub(crate) fn transfer(
-    left: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    right: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut <Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;


### PR DESCRIPTION
Current two RNG we provided in this crate does not meet FIPS requirements.

So, this PR updates all crypto algorithms that need to use RNG to have a function pointer for creating RNG. In this way, user could customize the RNG they want to use for each algorithm.

These PR also contains other necessary changes:
- Add unit tests.
- Fix clippy warnings.