### PR TITLE
Add support of customizing RNG for crypto algorithms

### DIFF
--- a/rustls-mbedcrypto-provider/src/agreement.rs
+++ b/rustls-mbedcrypto-provider/src/agreement.rs
@@ -8,7 +8,6 @@
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
 
 /// An ECDH key agreement algorithm.
-#[derive(Debug)]
 pub(crate) struct Algorithm {
     pub(crate) group_id: EcGroupId,
     pub(crate) public_key_len: usize,

--- a/rustls-mbedcrypto-provider/src/agreement.rs
+++ b/rustls-mbedcrypto-provider/src/agreement.rs
@@ -8,6 +8,7 @@
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
 
 /// An ECDH key agreement algorithm.
+#[derive(Debug)]
 pub(crate) struct Algorithm {
     pub(crate) group_id: EcGroupId,
     pub(crate) public_key_len: usize,

--- a/rustls-mbedcrypto-provider/src/agreement.rs
+++ b/rustls-mbedcrypto-provider/src/agreement.rs
@@ -5,6 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+use core::fmt;
+
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
 
 /// An ECDH key agreement algorithm.
@@ -12,6 +14,14 @@ pub(crate) struct Algorithm {
     pub(crate) group_id: EcGroupId,
     pub(crate) public_key_len: usize,
     pub(crate) max_signature_len: usize,
+}
+
+impl fmt::Debug for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Algorithm")
+            .field("group_id", &self.group_id)
+            .finish()
+    }
 }
 
 const ELEM_LEN: usize = 32;

--- a/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
+++ b/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
@@ -328,7 +328,6 @@ mod tests {
         let mut rng = crate::rng::rng_new().unwrap();
         let mut x_binary = vec![0; dhe_group.dhe_kx_group.priv_key_len];
         rng.random(&mut x_binary).unwrap();
-        print_vec("private", &x_binary);
 
         let x = Mpi::from_binary(&x_binary).unwrap();
         let x_pub = g.mod_exp(&x, &p).unwrap();

--- a/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
+++ b/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
@@ -24,7 +24,7 @@ mod constants;
 
 use crate::{
     fips_utils::constants::{get_ffdhe_q, get_known_ec_key, get_known_ffdhe_key_pair},
-    kx::{FFdheKxGroupWrapper, FfdheKxGroup},
+    kx::{FfdheKxGroup, FfdheKxGroupWrapper},
     log,
 };
 
@@ -199,7 +199,7 @@ fn fips_check_ec_pub_key_mbed<F: mbedtls::rng::Random>(ec_mbed_pk: &Pk, rng: &mu
 /// > standard does not require a PCT.
 ///
 /// [FIPS 140-3 IG]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-ig-announcements
-pub(super) fn ffdhe_pct<T: RngCallback>(dhe_group: &FFdheKxGroupWrapper<T>, y: &Mpi, y_pub: &Mpi) -> Result<(), rustls::Error> {
+pub(super) fn ffdhe_pct<T: RngCallback>(dhe_group: &FfdheKxGroupWrapper<T>, y: &Mpi, y_pub: &Mpi) -> Result<(), rustls::Error> {
     let p = Mpi::from_binary(dhe_group.dhe_kx_group.group.p).map_err(wrap_mbedtls_error_as_fips)?;
     let key_pair = get_known_ffdhe_key_pair(dhe_group.dhe_kx_group.named_group)
         .expect("validated")
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!("Other(OtherError(Mbedtls(AesBadInputData)))", rustls_test_dbg);
     }
 
-    fn create_ffdhe_key_pair<T: RngCallback>(dhe_group: &FFdheKxGroupWrapper<T>) -> (Mpi, Mpi) {
+    fn create_ffdhe_key_pair<T: RngCallback>(dhe_group: &FfdheKxGroupWrapper<T>) -> (Mpi, Mpi) {
         let g = Mpi::from_binary(dhe_group.dhe_kx_group.group.g).unwrap();
         let p = Mpi::from_binary(dhe_group.dhe_kx_group.group.p).unwrap();
         let mut rng = crate::rng::rng_new().unwrap();

--- a/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
+++ b/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
@@ -24,7 +24,7 @@ mod constants;
 
 use crate::{
     fips_utils::constants::{get_ffdhe_q, get_known_ec_key, get_known_ffdhe_key_pair},
-    kx::{DheKxGroup, DheKxGroupWrapper},
+    kx::{FFdheKxGroupWrapper, FfdheKxGroup},
     log,
 };
 
@@ -199,7 +199,7 @@ fn fips_check_ec_pub_key_mbed<F: mbedtls::rng::Random>(ec_mbed_pk: &Pk, rng: &mu
 /// > standard does not require a PCT.
 ///
 /// [FIPS 140-3 IG]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/fips-140-3-ig-announcements
-pub(super) fn ffdhe_pct<T: RngCallback>(dhe_group: &DheKxGroupWrapper<T>, y: &Mpi, y_pub: &Mpi) -> Result<(), rustls::Error> {
+pub(super) fn ffdhe_pct<T: RngCallback>(dhe_group: &FFdheKxGroupWrapper<T>, y: &Mpi, y_pub: &Mpi) -> Result<(), rustls::Error> {
     let p = Mpi::from_binary(dhe_group.dhe_kx_group.group.p).map_err(wrap_mbedtls_error_as_fips)?;
     let key_pair = get_known_ffdhe_key_pair(dhe_group.dhe_kx_group.named_group)
         .expect("validated")
@@ -322,7 +322,7 @@ mod tests {
         assert_eq!("Other(OtherError(Mbedtls(AesBadInputData)))", rustls_test_dbg);
     }
 
-    fn create_ffdhe_key_pair<T: RngCallback>(dhe_group: &DheKxGroupWrapper<T>) -> (Mpi, Mpi) {
+    fn create_ffdhe_key_pair<T: RngCallback>(dhe_group: &FFdheKxGroupWrapper<T>) -> (Mpi, Mpi) {
         let g = Mpi::from_binary(dhe_group.dhe_kx_group.group.g).unwrap();
         let p = Mpi::from_binary(dhe_group.dhe_kx_group.group.p).unwrap();
         let mut rng = crate::rng::rng_new().unwrap();

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -57,7 +57,6 @@ impl<T: RngCallback> fmt::Debug for KxGroup<T> {
         f.debug_struct("KxGroup")
             .field("name", &self.name)
             .field("agreement_algorithm", &self.agreement_algorithm.group_id)
-            .field("rng_provider", &self.rng_provider)
             .finish()
     }
 }
@@ -293,7 +292,6 @@ impl<T: RngCallback> fmt::Debug for DheKxGroup<T> {
             .field("named_group", &self.named_group)
             .field("group", &self.group)
             .field("priv_key_len", &self.priv_key_len)
-            .field("rng_provider", &self.rng_provider)
             .finish()
     }
 }
@@ -426,7 +424,7 @@ mod tests {
             debug_str.contains("agreement_algorithm: Curve25519"),
             "debug_str: {debug_str}"
         );
-        assert!(debug_str.contains("rng_provider: 0x"), "debug_str: {debug_str}");
+        assert!(!debug_str.contains("rng_provider"), "debug_str: {debug_str}");
     }
 
     #[test]
@@ -435,7 +433,7 @@ mod tests {
         assert!(debug_str.contains("DheKxGroup"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FFDHE2048"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FfdheGroup"), "debug_str: {debug_str}");
-        assert!(debug_str.contains("rng_provider: 0x"), "debug_str: {debug_str}");
+        assert!(!debug_str.contains("rng_provider"), "debug_str: {debug_str}");
     }
 
     #[test]

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -56,7 +56,7 @@ impl<T: RngCallback> fmt::Debug for KxGroup<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KxGroup")
             .field("name", &self.name)
-            .field("agreement_algorithm", &self.agreement_algorithm)
+            .field("agreement_algorithm", &self.agreement_algorithm.group_id)
             .field("rng_provider", &self.rng_provider)
             .finish()
     }
@@ -420,7 +420,13 @@ mod tests {
     #[test]
     fn test_kx_group_fmt_debug() {
         let debug_str = format!("{:?}", X25519_KX_GROUP);
-        assert!(debug_str.contains("KxGroup { name: X25519, agreement_algorithm: Algorithm { group_id: Curve25519, public_key_len: 32, max_signature_len: 64 }, rng_provider: 0x"), "debug_str: {debug_str}")
+        assert!(debug_str.contains("KxGroup"), "debug_str: {debug_str}");
+        assert!(debug_str.contains("name: X25519"), "debug_str: {debug_str}");
+        assert!(
+            debug_str.contains("agreement_algorithm: Curve25519"),
+            "debug_str: {debug_str}"
+        );
+        assert!(debug_str.contains("rng_provider: 0x"), "debug_str: {debug_str}");
     }
 
     #[test]

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -30,56 +30,74 @@ use rustls::ffdhe_groups;
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::Error;
 use rustls::NamedGroup;
-/// An EC key-exchange group supported by *mbedtls*.
+/// A wrapper type representing implmentation of an EC key-exchange group
+/// supported by *mbedtls*.
 ///
-/// All possible instances of this type are provided by the library in
-/// the `ALL_KX_GROUPS` array.
-pub struct KxGroup<T: RngCallback> {
-    /// The IANA "TLS Supported Groups" name of the group
-    name: NamedGroup,
-
-    /// The corresponding agreement algorithm
-    agreement_algorithm: &'static agreement::Algorithm,
+/// All possible instances of this type are provided by the library in the
+/// `ALL_KX_GROUPS` array.
+pub struct KxGroupWrapper<T: RngCallback> {
+    /// An EC key-exchange group
+    kx_group: KxGroup,
 
     /// Callback to produce RNGs when needed
     rng_provider: fn() -> Option<T>,
 }
 
-impl<T: RngCallback> KxGroup<T> {
-    /// Create a new [`KxGroup`] with given RNG provider callback.
-    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> KxGroup<F> {
-        KxGroup { rng_provider, name: self.name, agreement_algorithm: self.agreement_algorithm }
+/// An EC key-exchange group supported by *mbedtls*.
+#[derive(Debug, Clone, Copy)]
+struct KxGroup {
+    /// The corresponding agreement algorithm
+    agreement_algorithm: &'static agreement::Algorithm,
+
+    /// The IANA "TLS Supported Groups" name of the group
+    name: NamedGroup,
+}
+
+impl<T: RngCallback> KxGroupWrapper<T> {
+    /// Create a new [`KxGroupWrapper`] with given RNG provider callback.
+    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> KxGroupWrapper<F> {
+        KxGroupWrapper { rng_provider, kx_group: self.kx_group }
     }
 }
 
-impl<T: RngCallback> fmt::Debug for KxGroup<T> {
+impl<T: RngCallback> fmt::Debug for KxGroupWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KxGroup")
-            .field("name", &self.name)
-            .field("agreement_algorithm", &self.agreement_algorithm.group_id)
+        f.debug_struct("KxGroupWrapper")
+            .field("kx_group", &self.kx_group)
             .finish()
     }
 }
 
-impl<T: RngCallback + 'static> SupportedKxGroup for KxGroup<T> {
+impl<T: RngCallback + 'static> SupportedKxGroup for KxGroupWrapper<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let mut rng = (self.rng_provider)().ok_or(Error::FailedToGetRandomBytes)?;
 
         #[allow(unused_mut)]
-        let mut priv_key = generate_ec_key(self.agreement_algorithm.group_id, &mut rng)?;
+        let mut priv_key = generate_ec_key(
+            self.kx_group
+                .agreement_algorithm
+                .group_id,
+            &mut rng,
+        )?;
 
         // Only run fips check on applied NamedGroups
         #[cfg(feature = "fips")]
-        match self.name {
+        match self.name() {
             NamedGroup::secp256r1 | NamedGroup::secp384r1 | NamedGroup::secp521r1 => {
-                crate::fips_utils::fips_ec_pct(&mut priv_key, self.agreement_algorithm.group_id, &mut rng)?;
+                crate::fips_utils::fips_ec_pct(
+                    &mut priv_key,
+                    self.kx_group
+                        .agreement_algorithm
+                        .group_id,
+                    &mut rng,
+                )?;
             }
             _ => (),
         }
 
-        Ok(Box::new(KeyExchange {
-            name: self.name,
-            agreement_algorithm: self.agreement_algorithm,
+        Ok(Box::new(KeyExchangeImpl {
+            name: self.kx_group.name,
+            agreement_algorithm: self.kx_group.agreement_algorithm,
             priv_key,
             pub_key: OnceLock::new(),
             rng_provider: self.rng_provider,
@@ -87,7 +105,7 @@ impl<T: RngCallback + 'static> SupportedKxGroup for KxGroup<T> {
     }
 
     fn name(&self) -> NamedGroup {
-        self.name
+        self.kx_group.name
     }
 }
 
@@ -100,86 +118,92 @@ fn generate_ec_key<F: Random>(group_id: mbedtls::pk::EcGroupId, rng: &mut F) -> 
 /// Ephemeral ECDH on curve25519 (see RFC7748)
 pub static X25519: &dyn SupportedKxGroup = X25519_KX_GROUP;
 /// Ephemeral ECDH on curve25519 (see RFC7748)
-pub static X25519_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
-    name: NamedGroup::X25519,
-    agreement_algorithm: &agreement::X25519,
+pub static X25519_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
+    kx_group: KxGroup { name: NamedGroup::X25519, agreement_algorithm: &agreement::X25519 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
 pub static SECP256R1: &dyn SupportedKxGroup = SECP256R1_KX_GROUP;
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
-pub static SECP256R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
-    name: NamedGroup::secp256r1,
-    agreement_algorithm: &agreement::ECDH_P256,
+pub static SECP256R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
+    kx_group: KxGroup { name: NamedGroup::secp256r1, agreement_algorithm: &agreement::ECDH_P256 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
 pub static SECP384R1: &dyn SupportedKxGroup = SECP384R1_KX_GROUP;
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
-pub static SECP384R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
-    name: NamedGroup::secp384r1,
-    agreement_algorithm: &agreement::ECDH_P384,
+pub static SECP384R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
+    kx_group: KxGroup { name: NamedGroup::secp384r1, agreement_algorithm: &agreement::ECDH_P384 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp521r1 (aka NIST-P521)
 pub static SECP521R1: &dyn SupportedKxGroup = SECP521R1_KX_GROUP;
 /// Ephemeral ECDH on secp521r1 (aka NIST-P521)
-pub static SECP521R1_KX_GROUP: &KxGroup<MbedRng> = &KxGroup {
-    name: NamedGroup::secp521r1,
-    agreement_algorithm: &agreement::ECDH_P521,
+pub static SECP521R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
+    kx_group: KxGroup { name: NamedGroup::secp521r1, agreement_algorithm: &agreement::ECDH_P521 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
 pub static FFDHE2048: &dyn SupportedKxGroup = FFDHE2048_KX_GROUP;
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
-pub static FFDHE2048_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
-    named_group: NamedGroup::FFDHE2048,
-    group: ffdhe_groups::FFDHE2048,
-    priv_key_len: 36,
+pub static FFDHE2048_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
+    dhe_kx_group: DheKxGroup {
+        named_group: NamedGroup::FFDHE2048,
+        group: ffdhe_groups::FFDHE2048,
+        priv_key_len: 36,
+    },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
 pub static FFDHE3072: &dyn SupportedKxGroup = FFDHE3072_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE3072_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
-    named_group: NamedGroup::FFDHE3072,
-    group: ffdhe_groups::FFDHE3072,
-    priv_key_len: 40,
+pub static FFDHE3072_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
+    dhe_kx_group: DheKxGroup {
+        named_group: NamedGroup::FFDHE3072,
+        group: ffdhe_groups::FFDHE3072,
+        priv_key_len: 40,
+    },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
 pub static FFDHE4096: &dyn SupportedKxGroup = FFDHE4096_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE4096_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
-    named_group: NamedGroup::FFDHE4096,
-    group: ffdhe_groups::FFDHE4096,
-    priv_key_len: 48,
+pub static FFDHE4096_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
+    dhe_kx_group: DheKxGroup {
+        named_group: NamedGroup::FFDHE4096,
+        group: ffdhe_groups::FFDHE4096,
+        priv_key_len: 48,
+    },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
 pub static FFDHE6144: &dyn SupportedKxGroup = FFDHE6144_KX_GROUP;
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
-pub static FFDHE6144_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
-    named_group: NamedGroup::FFDHE6144,
-    group: ffdhe_groups::FFDHE6144,
-    priv_key_len: 56,
+pub static FFDHE6144_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
+    dhe_kx_group: DheKxGroup {
+        named_group: NamedGroup::FFDHE6144,
+        group: ffdhe_groups::FFDHE6144,
+        priv_key_len: 56,
+    },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
 pub static FFDHE8192: &dyn SupportedKxGroup = FFDHE8192_KX_GROUP;
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
-pub static FFDHE8192_KX_GROUP: &DheKxGroup<MbedRng> = &DheKxGroup {
-    named_group: NamedGroup::FFDHE8192,
-    group: ffdhe_groups::FFDHE8192,
-    priv_key_len: 64,
+pub static FFDHE8192_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
+    dhe_kx_group: DheKxGroup {
+        named_group: NamedGroup::FFDHE8192,
+        group: ffdhe_groups::FFDHE8192,
+        priv_key_len: 64,
+    },
     rng_provider: crate::rng::rng_new,
 };
 
@@ -192,11 +216,12 @@ pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[
 ];
 
 /// An in-progress ECDH key exchange.  This has the algorithm,
-/// our private key, and our public key.
-struct KeyExchange<T: RngCallback> {
-    name: NamedGroup,
+/// our private key, and our public key and RNG provider.
+struct KeyExchangeImpl<T: RngCallback> {
     /// The corresponding [`agreement::Algorithm`]
     agreement_algorithm: &'static agreement::Algorithm,
+    /// The IANA "TLS Supported Groups" name of the group
+    name: NamedGroup,
     /// Private key
     priv_key: PkMbed,
     /// Public key in binary format [`EcPoint`] without compression
@@ -205,7 +230,7 @@ struct KeyExchange<T: RngCallback> {
     rng_provider: fn() -> Option<T>,
 }
 
-impl<T: RngCallback> KeyExchange<T> {
+impl<T: RngCallback> KeyExchangeImpl<T> {
     fn get_pub_key(&self) -> mbedtls::Result<Vec<u8>> {
         let group = EcGroup::new(self.agreement_algorithm.group_id)?;
         self.priv_key
@@ -214,7 +239,7 @@ impl<T: RngCallback> KeyExchange<T> {
     }
 }
 
-impl<T: RngCallback> ActiveKeyExchange for KeyExchange<T> {
+impl<T: RngCallback> ActiveKeyExchange for KeyExchangeImpl<T> {
     /// Completes the key exchange, given the peer's public key.
     fn complete(mut self: Box<Self>, peer_public_key: &[u8]) -> Result<crypto::SharedSecret, Error> {
         let group_id = self.agreement_algorithm.group_id;
@@ -259,50 +284,51 @@ impl<T: RngCallback> ActiveKeyExchange for KeyExchange<T> {
     }
 }
 
-/// A DHE key-exchange group supported by *mbedtls*.
+/// A wrapper type representing the implementation of a DHE key-exchange group
+/// supported by *mbedtls*.
 ///
-/// All possible instances of this type are provided by the library in
-/// the `ALL_KX_GROUPS` array.
-pub struct DheKxGroup<T: RngCallback> {
-    /// The IANA "TLS Supported Groups" name of the group
-    pub(crate) named_group: NamedGroup,
-    /// FFDHE Group parameters
-    pub(crate) group: FfdheGroup<'static>,
-    /// Private key length
-    pub(crate) priv_key_len: usize,
+/// All possible instances of this type are provided by the library in the
+/// `ALL_KX_GROUPS` array.
+pub struct DheKxGroupWrapper<T: RngCallback> {
+    /// A DHE key-exchange group
+    pub(crate) dhe_kx_group: DheKxGroup,
     /// Callback to produce RNGs when needed
     rng_provider: fn() -> Option<T>,
 }
 
-impl<T: RngCallback> DheKxGroup<T> {
-    /// Create a new [`DheKxGroup`] with given RNG provider callback.
-    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> DheKxGroup<F> {
-        DheKxGroup {
-            rng_provider,
-            named_group: self.named_group,
-            group: self.group,
-            priv_key_len: self.priv_key_len,
-        }
+/// A DHE key-exchange group supported by *mbedtls*.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DheKxGroup {
+    /// FFDHE Group parameters
+    pub(crate) group: FfdheGroup<'static>,
+    /// The IANA "TLS Supported Groups" name of the group
+    pub(crate) named_group: NamedGroup,
+    /// Private key length
+    pub(crate) priv_key_len: usize,
+}
+
+impl<T: RngCallback> DheKxGroupWrapper<T> {
+    /// Create a new [`DheKxGroupWrapper`] with given RNG provider callback.
+    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> DheKxGroupWrapper<F> {
+        DheKxGroupWrapper { dhe_kx_group: self.dhe_kx_group, rng_provider }
     }
 }
 
-impl<T: RngCallback> fmt::Debug for DheKxGroup<T> {
+impl<T: RngCallback> fmt::Debug for DheKxGroupWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DheKxGroup")
-            .field("named_group", &self.named_group)
-            .field("group", &self.group)
-            .field("priv_key_len", &self.priv_key_len)
+        f.debug_struct("DheKxGroupWrapper")
+            .field("dhe_kx_group", &self.dhe_kx_group)
             .finish()
     }
 }
 
-impl<T: RngCallback> SupportedKxGroup for DheKxGroup<T> {
+impl<T: RngCallback> SupportedKxGroup for DheKxGroupWrapper<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
-        let g = Mpi::from_binary(self.group.g).map_err(mbedtls_err_to_rustls_error)?;
-        let p = Mpi::from_binary(self.group.p).map_err(mbedtls_err_to_rustls_error)?;
+        let g = Mpi::from_binary(self.dhe_kx_group.group.g).map_err(mbedtls_err_to_rustls_error)?;
+        let p = Mpi::from_binary(self.dhe_kx_group.group.p).map_err(mbedtls_err_to_rustls_error)?;
 
         let mut rng = (self.rng_provider)().ok_or(crypto::GetRandomFailed)?;
-        let mut x = vec![0; self.priv_key_len];
+        let mut x = vec![0; self.dhe_kx_group.priv_key_len];
         rng.random(&mut x)
             .map_err(|_| crypto::GetRandomFailed)?;
         let x = Mpi::from_binary(&x).map_err(|e| Error::General(format!("failed to make Bignum from random bytes: {}", e)))?;
@@ -313,23 +339,23 @@ impl<T: RngCallback> SupportedKxGroup for DheKxGroup<T> {
         #[cfg(feature = "fips")]
         crate::fips_utils::ffdhe_pct(self, &x, &x_pub)?;
 
-        Ok(Box::new(DheActiveKeyExchange::new(
-            self.named_group,
-            self.group,
+        Ok(Box::new(DheActiveKeyExchangeImpl::new(
+            self.dhe_kx_group.named_group,
+            self.dhe_kx_group.group,
             Mutex::new(p),
             Mutex::new(x),
             x_pub
-                .to_binary_padded(self.group.p.len())
+                .to_binary_padded(self.dhe_kx_group.group.p.len())
                 .map_err(mbedtls_err_to_rustls_error)?,
         )))
     }
 
     fn name(&self) -> NamedGroup {
-        self.named_group
+        self.dhe_kx_group.named_group
     }
 }
 
-pub(crate) struct DheActiveKeyExchange {
+pub(crate) struct DheActiveKeyExchangeImpl {
     named_group: NamedGroup,
     group: FfdheGroup<'static>,
     // Using Mutex just because `Mpi` is not currently `Sync`
@@ -339,7 +365,7 @@ pub(crate) struct DheActiveKeyExchange {
     x_pub: Vec<u8>,
 }
 
-impl DheActiveKeyExchange {
+impl DheActiveKeyExchangeImpl {
     pub(crate) fn new(
         named_group: NamedGroup,
         group: FfdheGroup<'static>,
@@ -351,7 +377,7 @@ impl DheActiveKeyExchange {
     }
 }
 
-impl ActiveKeyExchange for DheActiveKeyExchange {
+impl ActiveKeyExchange for DheActiveKeyExchangeImpl {
     fn complete(self: Box<Self>, peer_pub_key: &[u8]) -> Result<crypto::SharedSecret, Error> {
         let y_pub = Mpi::from_binary(peer_pub_key).map_err(mbedtls_err_to_rustls_error)?;
 
@@ -418,13 +444,10 @@ mod tests {
     #[test]
     fn test_kx_group_fmt_debug() {
         let debug_str = format!("{:?}", X25519_KX_GROUP);
-        assert!(debug_str.contains("KxGroup"), "debug_str: {debug_str}");
-        assert!(debug_str.contains("name: X25519"), "debug_str: {debug_str}");
-        assert!(
-            debug_str.contains("agreement_algorithm: Curve25519"),
-            "debug_str: {debug_str}"
-        );
-        assert!(!debug_str.contains("rng_provider"), "debug_str: {debug_str}");
+        assert_eq!(
+            debug_str,
+            "KxGroupWrapper { kx_group: KxGroup { agreement_algorithm: Algorithm { group_id: Curve25519 }, name: X25519 } }",
+        )
     }
 
     #[test]

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -30,14 +30,14 @@ use rustls::ffdhe_groups;
 use rustls::ffdhe_groups::FfdheGroup;
 use rustls::Error;
 use rustls::NamedGroup;
-/// A wrapper type representing implmentation of an EC key-exchange group
+/// A wrapper type representing implementation of an EC key-exchange group
 /// supported by *mbedtls*.
 ///
 /// All possible instances of this type are provided by the library in the
 /// `ALL_KX_GROUPS` array.
-pub struct KxGroupWrapper<T: RngCallback> {
+pub struct EcdhKxGroupWrapper<T: RngCallback> {
     /// An EC key-exchange group
-    kx_group: KxGroup,
+    kx_group: EcdhKxGroup,
 
     /// Callback to produce RNGs when needed
     rng_provider: fn() -> Option<T>,
@@ -45,7 +45,7 @@ pub struct KxGroupWrapper<T: RngCallback> {
 
 /// An EC key-exchange group supported by *mbedtls*.
 #[derive(Debug, Clone, Copy)]
-struct KxGroup {
+struct EcdhKxGroup {
     /// The corresponding agreement algorithm
     agreement_algorithm: &'static agreement::Algorithm,
 
@@ -53,22 +53,22 @@ struct KxGroup {
     name: NamedGroup,
 }
 
-impl<T: RngCallback> KxGroupWrapper<T> {
-    /// Create a new [`KxGroupWrapper`] with given RNG provider callback.
-    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> KxGroupWrapper<F> {
-        KxGroupWrapper { rng_provider, kx_group: self.kx_group }
+impl<T: RngCallback> EcdhKxGroupWrapper<T> {
+    /// Create a new [`EcdhKxGroupWrapper`] with given RNG provider callback.
+    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> EcdhKxGroupWrapper<F> {
+        EcdhKxGroupWrapper { rng_provider, kx_group: self.kx_group }
     }
 }
 
-impl<T: RngCallback> fmt::Debug for KxGroupWrapper<T> {
+impl<T: RngCallback> fmt::Debug for EcdhKxGroupWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("KxGroupWrapper")
+        f.debug_struct("EcdhKxGroupWrapper")
             .field("kx_group", &self.kx_group)
             .finish()
     }
 }
 
-impl<T: RngCallback + 'static> SupportedKxGroup for KxGroupWrapper<T> {
+impl<T: RngCallback + 'static> SupportedKxGroup for EcdhKxGroupWrapper<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let mut rng = (self.rng_provider)().ok_or(Error::FailedToGetRandomBytes)?;
 
@@ -95,7 +95,7 @@ impl<T: RngCallback + 'static> SupportedKxGroup for KxGroupWrapper<T> {
             _ => (),
         }
 
-        Ok(Box::new(KeyExchangeImpl {
+        Ok(Box::new(EcdhKeyExchangeImpl {
             name: self.kx_group.name,
             agreement_algorithm: self.kx_group.agreement_algorithm,
             priv_key,
@@ -118,40 +118,40 @@ fn generate_ec_key<F: Random>(group_id: mbedtls::pk::EcGroupId, rng: &mut F) -> 
 /// Ephemeral ECDH on curve25519 (see RFC7748)
 pub static X25519: &dyn SupportedKxGroup = X25519_KX_GROUP;
 /// Ephemeral ECDH on curve25519 (see RFC7748)
-pub static X25519_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
-    kx_group: KxGroup { name: NamedGroup::X25519, agreement_algorithm: &agreement::X25519 },
+pub static X25519_KX_GROUP: &EcdhKxGroupWrapper<MbedRng> = &EcdhKxGroupWrapper {
+    kx_group: EcdhKxGroup { name: NamedGroup::X25519, agreement_algorithm: &agreement::X25519 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
 pub static SECP256R1: &dyn SupportedKxGroup = SECP256R1_KX_GROUP;
 /// Ephemeral ECDH on secp256r1 (aka NIST-P256)
-pub static SECP256R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
-    kx_group: KxGroup { name: NamedGroup::secp256r1, agreement_algorithm: &agreement::ECDH_P256 },
+pub static SECP256R1_KX_GROUP: &EcdhKxGroupWrapper<MbedRng> = &EcdhKxGroupWrapper {
+    kx_group: EcdhKxGroup { name: NamedGroup::secp256r1, agreement_algorithm: &agreement::ECDH_P256 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
 pub static SECP384R1: &dyn SupportedKxGroup = SECP384R1_KX_GROUP;
 /// Ephemeral ECDH on secp384r1 (aka NIST-P384)
-pub static SECP384R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
-    kx_group: KxGroup { name: NamedGroup::secp384r1, agreement_algorithm: &agreement::ECDH_P384 },
+pub static SECP384R1_KX_GROUP: &EcdhKxGroupWrapper<MbedRng> = &EcdhKxGroupWrapper {
+    kx_group: EcdhKxGroup { name: NamedGroup::secp384r1, agreement_algorithm: &agreement::ECDH_P384 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// Ephemeral ECDH on secp521r1 (aka NIST-P521)
 pub static SECP521R1: &dyn SupportedKxGroup = SECP521R1_KX_GROUP;
 /// Ephemeral ECDH on secp521r1 (aka NIST-P521)
-pub static SECP521R1_KX_GROUP: &KxGroupWrapper<MbedRng> = &KxGroupWrapper {
-    kx_group: KxGroup { name: NamedGroup::secp521r1, agreement_algorithm: &agreement::ECDH_P521 },
+pub static SECP521R1_KX_GROUP: &EcdhKxGroupWrapper<MbedRng> = &EcdhKxGroupWrapper {
+    kx_group: EcdhKxGroup { name: NamedGroup::secp521r1, agreement_algorithm: &agreement::ECDH_P521 },
     rng_provider: crate::rng::rng_new,
 };
 
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
 pub static FFDHE2048: &dyn SupportedKxGroup = FFDHE2048_KX_GROUP;
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
-pub static FFDHE2048_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
-    dhe_kx_group: DheKxGroup {
+pub static FFDHE2048_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+    dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE2048,
         group: ffdhe_groups::FFDHE2048,
         priv_key_len: 36,
@@ -162,8 +162,8 @@ pub static FFDHE2048_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper 
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
 pub static FFDHE3072: &dyn SupportedKxGroup = FFDHE3072_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE3072_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
-    dhe_kx_group: DheKxGroup {
+pub static FFDHE3072_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+    dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE3072,
         group: ffdhe_groups::FFDHE3072,
         priv_key_len: 40,
@@ -174,8 +174,8 @@ pub static FFDHE3072_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper 
 /// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
 pub static FFDHE4096: &dyn SupportedKxGroup = FFDHE4096_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE4096_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
-    dhe_kx_group: DheKxGroup {
+pub static FFDHE4096_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+    dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE4096,
         group: ffdhe_groups::FFDHE4096,
         priv_key_len: 48,
@@ -186,8 +186,8 @@ pub static FFDHE4096_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper 
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
 pub static FFDHE6144: &dyn SupportedKxGroup = FFDHE6144_KX_GROUP;
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
-pub static FFDHE6144_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
-    dhe_kx_group: DheKxGroup {
+pub static FFDHE6144_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+    dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE6144,
         group: ffdhe_groups::FFDHE6144,
         priv_key_len: 56,
@@ -198,8 +198,8 @@ pub static FFDHE6144_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper 
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
 pub static FFDHE8192: &dyn SupportedKxGroup = FFDHE8192_KX_GROUP;
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
-pub static FFDHE8192_KX_GROUP: &DheKxGroupWrapper<MbedRng> = &DheKxGroupWrapper {
-    dhe_kx_group: DheKxGroup {
+pub static FFDHE8192_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+    dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE8192,
         group: ffdhe_groups::FFDHE8192,
         priv_key_len: 64,
@@ -217,7 +217,7 @@ pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[
 
 /// An in-progress ECDH key exchange.  This has the algorithm,
 /// our private key, and our public key and RNG provider.
-struct KeyExchangeImpl<T: RngCallback> {
+struct EcdhKeyExchangeImpl<T: RngCallback> {
     /// The corresponding [`agreement::Algorithm`]
     agreement_algorithm: &'static agreement::Algorithm,
     /// The IANA "TLS Supported Groups" name of the group
@@ -230,7 +230,7 @@ struct KeyExchangeImpl<T: RngCallback> {
     rng_provider: fn() -> Option<T>,
 }
 
-impl<T: RngCallback> KeyExchangeImpl<T> {
+impl<T: RngCallback> EcdhKeyExchangeImpl<T> {
     fn get_pub_key(&self) -> mbedtls::Result<Vec<u8>> {
         let group = EcGroup::new(self.agreement_algorithm.group_id)?;
         self.priv_key
@@ -239,7 +239,7 @@ impl<T: RngCallback> KeyExchangeImpl<T> {
     }
 }
 
-impl<T: RngCallback> ActiveKeyExchange for KeyExchangeImpl<T> {
+impl<T: RngCallback> ActiveKeyExchange for EcdhKeyExchangeImpl<T> {
     /// Completes the key exchange, given the peer's public key.
     fn complete(mut self: Box<Self>, peer_public_key: &[u8]) -> Result<crypto::SharedSecret, Error> {
         let group_id = self.agreement_algorithm.group_id;
@@ -284,21 +284,21 @@ impl<T: RngCallback> ActiveKeyExchange for KeyExchangeImpl<T> {
     }
 }
 
-/// A wrapper type representing the implementation of a DHE key-exchange group
+/// A wrapper type representing the implementation of a FFDHE key-exchange group
 /// supported by *mbedtls*.
 ///
 /// All possible instances of this type are provided by the library in the
 /// `ALL_KX_GROUPS` array.
-pub struct DheKxGroupWrapper<T: RngCallback> {
-    /// A DHE key-exchange group
-    pub(crate) dhe_kx_group: DheKxGroup,
+pub struct FFdheKxGroupWrapper<T: RngCallback> {
+    /// A FFDHE key-exchange group
+    pub(crate) dhe_kx_group: FfdheKxGroup,
     /// Callback to produce RNGs when needed
     rng_provider: fn() -> Option<T>,
 }
 
-/// A DHE key-exchange group supported by *mbedtls*.
+/// A FFDHE key-exchange group supported by *mbedtls*.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct DheKxGroup {
+pub(crate) struct FfdheKxGroup {
     /// FFDHE Group parameters
     pub(crate) group: FfdheGroup<'static>,
     /// The IANA "TLS Supported Groups" name of the group
@@ -307,22 +307,22 @@ pub(crate) struct DheKxGroup {
     pub(crate) priv_key_len: usize,
 }
 
-impl<T: RngCallback> DheKxGroupWrapper<T> {
-    /// Create a new [`DheKxGroupWrapper`] with given RNG provider callback.
-    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> DheKxGroupWrapper<F> {
-        DheKxGroupWrapper { dhe_kx_group: self.dhe_kx_group, rng_provider }
+impl<T: RngCallback> FFdheKxGroupWrapper<T> {
+    /// Create a new [`FFdheKxGroupWrapper`] with given RNG provider callback.
+    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> FFdheKxGroupWrapper<F> {
+        FFdheKxGroupWrapper { dhe_kx_group: self.dhe_kx_group, rng_provider }
     }
 }
 
-impl<T: RngCallback> fmt::Debug for DheKxGroupWrapper<T> {
+impl<T: RngCallback> fmt::Debug for FFdheKxGroupWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DheKxGroupWrapper")
+        f.debug_struct("FFdheKxGroupWrapper")
             .field("dhe_kx_group", &self.dhe_kx_group)
             .finish()
     }
 }
 
-impl<T: RngCallback> SupportedKxGroup for DheKxGroupWrapper<T> {
+impl<T: RngCallback> SupportedKxGroup for FFdheKxGroupWrapper<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let g = Mpi::from_binary(self.dhe_kx_group.group.g).map_err(mbedtls_err_to_rustls_error)?;
         let p = Mpi::from_binary(self.dhe_kx_group.group.p).map_err(mbedtls_err_to_rustls_error)?;
@@ -446,14 +446,14 @@ mod tests {
         let debug_str = format!("{:?}", X25519_KX_GROUP);
         assert_eq!(
             debug_str,
-            "KxGroupWrapper { kx_group: KxGroup { agreement_algorithm: Algorithm { group_id: Curve25519 }, name: X25519 } }",
+            "EcdhKxGroupWrapper { kx_group: EcdhKxGroup { agreement_algorithm: Algorithm { group_id: Curve25519 }, name: X25519 } }",
         )
     }
 
     #[test]
     fn test_dhe_kx_group_fmt_debug() {
         let debug_str = format!("{:?}", FFDHE2048_KX_GROUP);
-        assert!(debug_str.contains("DheKxGroup"), "debug_str: {debug_str}");
+        assert!(debug_str.contains("FfdheKxGroup"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FFDHE2048"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FfdheGroup"), "debug_str: {debug_str}");
         assert!(!debug_str.contains("rng_provider"), "debug_str: {debug_str}");

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -150,7 +150,7 @@ pub static SECP521R1_KX_GROUP: &EcdhKxGroupWrapper<MbedRng> = &EcdhKxGroupWrappe
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
 pub static FFDHE2048: &dyn SupportedKxGroup = FFDHE2048_KX_GROUP;
 /// DHE group [FFDHE2048](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.1)
-pub static FFDHE2048_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+pub static FFDHE2048_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE2048,
         group: ffdhe_groups::FFDHE2048,
@@ -162,7 +162,7 @@ pub static FFDHE2048_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrap
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
 pub static FFDHE3072: &dyn SupportedKxGroup = FFDHE3072_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE3072_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+pub static FFDHE3072_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE3072,
         group: ffdhe_groups::FFDHE3072,
@@ -174,7 +174,7 @@ pub static FFDHE3072_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrap
 /// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
 pub static FFDHE4096: &dyn SupportedKxGroup = FFDHE4096_KX_GROUP;
 /// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
-pub static FFDHE4096_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+pub static FFDHE4096_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE4096,
         group: ffdhe_groups::FFDHE4096,
@@ -186,7 +186,7 @@ pub static FFDHE4096_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrap
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
 pub static FFDHE6144: &dyn SupportedKxGroup = FFDHE6144_KX_GROUP;
 /// DHE group [FFDHE6144](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.4)
-pub static FFDHE6144_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+pub static FFDHE6144_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE6144,
         group: ffdhe_groups::FFDHE6144,
@@ -198,7 +198,7 @@ pub static FFDHE6144_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrap
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
 pub static FFDHE8192: &dyn SupportedKxGroup = FFDHE8192_KX_GROUP;
 /// DHE group [FFDHE8192](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.5)
-pub static FFDHE8192_KX_GROUP: &FFdheKxGroupWrapper<MbedRng> = &FFdheKxGroupWrapper {
+pub static FFDHE8192_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE8192,
         group: ffdhe_groups::FFDHE8192,
@@ -289,7 +289,7 @@ impl<T: RngCallback> ActiveKeyExchange for EcdhKeyExchangeImpl<T> {
 ///
 /// All possible instances of this type are provided by the library in the
 /// `ALL_KX_GROUPS` array.
-pub struct FFdheKxGroupWrapper<T: RngCallback> {
+pub struct FfdheKxGroupWrapper<T: RngCallback> {
     /// A FFDHE key-exchange group
     pub(crate) dhe_kx_group: FfdheKxGroup,
     /// Callback to produce RNGs when needed
@@ -307,22 +307,22 @@ pub(crate) struct FfdheKxGroup {
     pub(crate) priv_key_len: usize,
 }
 
-impl<T: RngCallback> FFdheKxGroupWrapper<T> {
-    /// Create a new [`FFdheKxGroupWrapper`] with given RNG provider callback.
-    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> FFdheKxGroupWrapper<F> {
-        FFdheKxGroupWrapper { dhe_kx_group: self.dhe_kx_group, rng_provider }
+impl<T: RngCallback> FfdheKxGroupWrapper<T> {
+    /// Create a new [`FfdheKxGroupWrapper`] with given RNG provider callback.
+    pub const fn with_rng_provider<F: RngCallback>(&self, rng_provider: fn() -> Option<F>) -> FfdheKxGroupWrapper<F> {
+        FfdheKxGroupWrapper { dhe_kx_group: self.dhe_kx_group, rng_provider }
     }
 }
 
-impl<T: RngCallback> fmt::Debug for FFdheKxGroupWrapper<T> {
+impl<T: RngCallback> fmt::Debug for FfdheKxGroupWrapper<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FFdheKxGroupWrapper")
+        f.debug_struct("FfdheKxGroupWrapper")
             .field("dhe_kx_group", &self.dhe_kx_group)
             .finish()
     }
 }
 
-impl<T: RngCallback> SupportedKxGroup for FFdheKxGroupWrapper<T> {
+impl<T: RngCallback> SupportedKxGroup for FfdheKxGroupWrapper<T> {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let g = Mpi::from_binary(self.dhe_kx_group.group.g).map_err(mbedtls_err_to_rustls_error)?;
         let p = Mpi::from_binary(self.dhe_kx_group.group.p).map_err(mbedtls_err_to_rustls_error)?;

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -173,7 +173,7 @@ pub static FFDHE3072_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrap
 
 /// DHE group [FFDHE4096](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
 pub static FFDHE4096: &dyn SupportedKxGroup = FFDHE4096_KX_GROUP;
-/// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.2)
+/// DHE group [FFDHE3072](https://www.rfc-editor.org/rfc/rfc7919.html#appendix-A.3)
 pub static FFDHE4096_KX_GROUP: &FfdheKxGroupWrapper<MbedRng> = &FfdheKxGroupWrapper {
     dhe_kx_group: FfdheKxGroup {
         named_group: NamedGroup::FFDHE4096,

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -115,33 +115,41 @@ use rustls::{
 
 /// RNG supported by *mbedtls*
 pub mod rng {
-    #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
-    use mbedtls::rng::{CtrDrbg, OsEntropy};
 
-    /// Type alias for the a RNG(implemented by using [`CtrDrbg`]) supported
-    /// by [*mbedtls*], it always use [`OsEntrypy`].
+    /// Type alias for the a RNG(implemented by using [`mbedtls::rng::CtrDrbg`]) supported
+    /// by [*mbedtls*], it always use [`mbedtls::rng::OsEntropy`].
+    ///
+    /// [*mbedtls*]: https://github.com/fortanix/rust-mbedtls
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
-    pub type MbedRng = CtrDrbg;
+    pub type MbedRng = mbedtls::rng::CtrDrbg;
 
-    /// Get a RNG supported by *mbedtls*
+    /// Get a RNG supported by [*mbedtls*].
+    ///
+    /// The RNG is implemented by using [`mbedtls::rng::CtrDrbg`] and it always uses
+    /// [`mbedtls::rng::OsEntropy`].
+    ///
+    /// [*mbedtls*]: https://github.com/fortanix/rust-mbedtls
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
     pub fn rng_new() -> Option<MbedRng> {
-        let entropy = alloc::sync::Arc::new(OsEntropy::new());
-        CtrDrbg::new(entropy, None).ok()
+        let entropy = alloc::sync::Arc::new(mbedtls::rng::OsEntropy::new());
+        mbedtls::rng::CtrDrbg::new(entropy, None).ok()
     }
 
-    #[cfg(any(target_env = "sgx", feature = "rdrand"))]
-    use mbedtls::rng::Rdrand;
-
-    /// Type alias for the a RNG(implemented by using [`Rdrand`]) supported by
+    /// Type alias for the a RNG(implemented by using [`mbedtls::rng::Rdrand`]) supported by
     /// [*mbedtls*].
+    ///
+    /// [*mbedtls*]: https://github.com/fortanix/rust-mbedtls
     #[cfg(any(target_env = "sgx", feature = "rdrand"))]
-    pub type MbedRng = Rdrand;
+    pub type MbedRng = mbedtls::rng::Rdrand;
 
-    /// Get a RNG supported by *mbedtls*
+    /// Get a RNG supported by [*mbedtls*].
+    ///
+    /// The RNG is implemented by using [`mbedtls::rng::Rdrand`].
+    ///
+    /// [*mbedtls*]: https://github.com/fortanix/rust-mbedtls
     #[cfg(any(target_env = "sgx", feature = "rdrand"))]
     pub fn rng_new() -> Option<MbedRng> {
-        Some(Rdrand)
+        Some(mbedtls::rng::Rdrand)
     }
 }
 

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -118,7 +118,8 @@ pub mod rng {
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
     use mbedtls::rng::{CtrDrbg, OsEntropy};
 
-    /// Type alias for the RNG supported by *mbedtls*
+    /// Type alias for the a RNG(implemented by using [`CtrDrbg`]) supported
+    /// by [*mbedtls*], it always use [`OsEntrypy`].
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
     pub type MbedRng = CtrDrbg;
 
@@ -132,7 +133,8 @@ pub mod rng {
     #[cfg(any(target_env = "sgx", feature = "rdrand"))]
     use mbedtls::rng::Rdrand;
 
-    /// Type alias for the RNG supported by *mbedtls*
+    /// Type alias for the a RNG(implemented by using [`Rdrand`]) supported by
+    /// [*mbedtls*].
     #[cfg(any(target_env = "sgx", feature = "rdrand"))]
     pub type MbedRng = Rdrand;
 

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -92,7 +92,8 @@ pub(crate) mod fips_utils;
 pub mod hash;
 /// Hmac algorithms
 pub mod hmac;
-pub(crate) mod kx;
+/// Key exchange algorithms
+pub mod kx;
 
 #[cfg(feature = "self_tests")]
 pub mod self_tests;
@@ -117,19 +118,27 @@ pub mod rng {
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
     use mbedtls::rng::{CtrDrbg, OsEntropy};
 
-    #[cfg(any(target_env = "sgx", feature = "rdrand"))]
-    use mbedtls::rng::Rdrand;
+    /// Type alias for the RNG supported by *mbedtls*
+    #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
+    pub type MbedRng = CtrDrbg;
 
     /// Get a RNG supported by *mbedtls*
     #[cfg(not(any(target_env = "sgx", feature = "rdrand")))]
-    pub fn rng_new() -> Option<CtrDrbg> {
+    pub fn rng_new() -> Option<MbedRng> {
         let entropy = alloc::sync::Arc::new(OsEntropy::new());
         CtrDrbg::new(entropy, None).ok()
     }
 
+    #[cfg(any(target_env = "sgx", feature = "rdrand"))]
+    use mbedtls::rng::Rdrand;
+
+    /// Type alias for the RNG supported by *mbedtls*
+    #[cfg(any(target_env = "sgx", feature = "rdrand"))]
+    pub type MbedRng = Rdrand;
+
     /// Get a RNG supported by *mbedtls*
     #[cfg(any(target_env = "sgx", feature = "rdrand"))]
-    pub const fn rng_new() -> Option<Rdrand> {
+    pub fn rng_new() -> Option<MbedRng> {
         Some(Rdrand)
     }
 }
@@ -169,7 +178,7 @@ impl KeyProvider for MbedtlsKeyProvider {
         &self,
         key_der: webpki::types::PrivateKeyDer<'static>,
     ) -> Result<alloc::sync::Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-        Ok(alloc::sync::Arc::new(sign::MbedTlsPkSigningKey::new(&key_der)?))
+        Ok(alloc::sync::Arc::new(sign::MbedTlsPkSigningKey::new(&key_der, rng::rng_new)?))
     }
 }
 

--- a/rustls-mbedcrypto-provider/src/lib.rs
+++ b/rustls-mbedcrypto-provider/src/lib.rs
@@ -188,7 +188,10 @@ impl KeyProvider for MbedtlsKeyProvider {
         &self,
         key_der: webpki::types::PrivateKeyDer<'static>,
     ) -> Result<alloc::sync::Arc<dyn rustls::sign::SigningKey>, rustls::Error> {
-        Ok(alloc::sync::Arc::new(sign::MbedTlsPkSigningKey::new(&key_der, rng::rng_new)?))
+        Ok(alloc::sync::Arc::new(sign::MbedTlsPkSigningKeyWrapper::new(
+            &key_der,
+            rng::rng_new,
+        )?))
     }
 }
 

--- a/rustls-mbedcrypto-provider/src/self_tests.rs
+++ b/rustls-mbedcrypto-provider/src/self_tests.rs
@@ -232,7 +232,7 @@ pub fn ffdhe_crypto_algo_self_test() {
     let self_public_key_vec = self_public_key
         .to_binary_padded(group.p.len())
         .unwrap();
-    let dhe_kx = Box::new(crate::kx::DheActiveKeyExchange::new(
+    let dhe_kx = Box::new(crate::kx::DheActiveKeyExchangeImpl::new(
         named_group,
         group,
         std::sync::Mutex::new(p),

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -3,34 +3,39 @@ use alloc::vec;
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 use mbedtls::pk::{EcGroupId, ECDSA_MAX_LEN};
+use mbedtls::rng::RngCallback;
 use rustls::{pki_types, SignatureScheme};
 use std::sync::Mutex;
 use utils::error::mbedtls_err_into_rustls_err;
 use utils::hash::{buffer_for_hash_type, rustls_signature_scheme_to_mbedtls_hash_type};
 use utils::pk::{get_signature_schema_from_offered, pk_type_to_signature_algo, rustls_signature_scheme_to_mbedtls_pk_options};
 
-struct MbedTlsSigner(Arc<Mutex<mbedtls::pk::Pk>>, SignatureScheme);
+struct MbedTlsSigner<T: RngCallback> {
+    pk: Arc<Mutex<mbedtls::pk::Pk>>,
+    signature_scheme: SignatureScheme,
+    rng_provider: fn() -> Option<T>,
+}
 
-impl Debug for MbedTlsSigner {
+impl<T: RngCallback> Debug for MbedTlsSigner<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("MbedTlsSigner")
             .field(&"Arc<Mutex<mbedtls::pk::Pk>>")
-            .field(&self.1)
+            .field(&self.signature_scheme)
             .finish()
     }
 }
 
-impl rustls::sign::Signer for MbedTlsSigner {
+impl<T: RngCallback> rustls::sign::Signer for MbedTlsSigner<T> {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
-        let hash_type = rustls_signature_scheme_to_mbedtls_hash_type(self.1);
+        let hash_type = rustls_signature_scheme_to_mbedtls_hash_type(self.signature_scheme);
         let mut hash = buffer_for_hash_type(hash_type).ok_or_else(|| rustls::Error::General("unexpected hash type".into()))?;
         let hash_size = mbedtls::hash::Md::hash(hash_type, message, &mut hash).map_err(mbedtls_err_into_rustls_err)?;
 
         let mut pk = self
-            .0
+            .pk
             .lock()
             .expect("poisoned PK lock!");
-        if let Some(opts) = rustls_signature_scheme_to_mbedtls_pk_options(self.1) {
+        if let Some(opts) = rustls_signature_scheme_to_mbedtls_pk_options(self.signature_scheme) {
             pk.set_options(opts);
         }
 
@@ -46,7 +51,7 @@ impl rustls::sign::Signer for MbedTlsSigner {
                 hash_type,
                 &hash[..hash_size],
                 &mut sig,
-                &mut crate::rng::rng_new().ok_or(rustls::Error::FailedToGetRandomBytes)?,
+                &mut (self.rng_provider)().ok_or(rustls::Error::FailedToGetRandomBytes)?,
             )
             .map_err(mbedtls_err_into_rustls_err)?;
         sig.truncate(sig_len);
@@ -54,22 +59,23 @@ impl rustls::sign::Signer for MbedTlsSigner {
     }
 
     fn scheme(&self) -> SignatureScheme {
-        self.1
+        self.signature_scheme
     }
 }
 
 /// A [`SigningKey`] implemented by using [`mbedtls`]
 ///
 /// [`SigningKey`]: rustls::sign::SigningKey
-pub struct MbedTlsPkSigningKey {
+pub struct MbedTlsPkSigningKey<T: RngCallback> {
     pk: Arc<Mutex<mbedtls::pk::Pk>>,
     pk_type: mbedtls::pk::Type,
     signature_algorithm: rustls::SignatureAlgorithm,
     ec_signature_scheme: Option<SignatureScheme>,
     rsa_scheme_prefer_order_list: &'static [SignatureScheme],
+    rng_provider: fn() -> Option<T>,
 }
 
-impl Debug for MbedTlsPkSigningKey {
+impl<T: RngCallback> Debug for MbedTlsPkSigningKey<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MbedTlsPkSigningKey")
             .field("pk", &"Arc<Mutex<mbedtls::pk::Pk>>")
@@ -80,16 +86,16 @@ impl Debug for MbedTlsPkSigningKey {
     }
 }
 
-impl MbedTlsPkSigningKey {
+impl<T: RngCallback> MbedTlsPkSigningKey<T> {
     /// Make a new [`MbedTlsPkSigningKey`] from a DER encoding.
-    pub fn new(der: &pki_types::PrivateKeyDer<'_>) -> Result<Self, rustls::Error> {
+    pub fn new(der: &pki_types::PrivateKeyDer<'_>, rng_provider: fn() -> Option<T>) -> Result<Self, rustls::Error> {
         let pk = mbedtls::pk::Pk::from_private_key(der.secret_der(), None)
             .map_err(|err| rustls::Error::Other(rustls::OtherError(Arc::new(err))))?;
-        Self::from_pk(pk)
+        Self::from_pk(pk, rng_provider)
     }
 
     /// Make a new [`MbedTlsPkSigningKey`] from a [`mbedtls::pk::Pk`].
-    pub fn from_pk(pk: mbedtls::pk::Pk) -> Result<Self, rustls::Error> {
+    pub fn from_pk(pk: mbedtls::pk::Pk, rng_provider: fn() -> Option<T>) -> Result<Self, rustls::Error> {
         let pk_type = pk.pk_type();
         let signature_algorithm = pk_type_to_signature_algo(pk_type)
             .ok_or(rustls::Error::General(String::from("MbedTlsPkSigningKey: invalid pk type")))?;
@@ -118,6 +124,7 @@ impl MbedTlsPkSigningKey {
             signature_algorithm,
             ec_signature_scheme,
             rsa_scheme_prefer_order_list: DEFAULT_RSA_SIGNATURE_SCHEME_PREFER_LIST,
+            rng_provider,
         })
     }
 
@@ -137,7 +144,7 @@ pub const DEFAULT_RSA_SIGNATURE_SCHEME_PREFER_LIST: &[SignatureScheme] = &[
     SignatureScheme::RSA_PKCS1_SHA256,
 ];
 
-impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
+impl<T: RngCallback + 'static> rustls::sign::SigningKey for MbedTlsPkSigningKey<T> {
     fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn rustls::sign::Signer>> {
         let scheme = get_signature_schema_from_offered(
             self.pk_type,
@@ -145,7 +152,11 @@ impl rustls::sign::SigningKey for MbedTlsPkSigningKey {
             self.ec_signature_scheme,
             self.rsa_scheme_prefer_order_list,
         )?;
-        let signer = MbedTlsSigner(Arc::clone(&self.pk), scheme);
+        let signer = MbedTlsSigner {
+            pk: Arc::clone(&self.pk),
+            signature_scheme: scheme,
+            rng_provider: self.rng_provider,
+        };
         Some(Box::new(signer))
     }
 
@@ -168,7 +179,7 @@ mod tests {
                 .unwrap()
                 .unwrap()
                 .into();
-        let key = MbedTlsPkSigningKey::new(&der).unwrap();
+        let key = MbedTlsPkSigningKey::new(&der, crate::rng::rng_new).unwrap();
         assert_eq!("MbedTlsPkSigningKey { pk: \"Arc<Mutex<mbedtls::pk::Pk>>\", pk_type: Eckey, signature_algorithm: ECDSA, ec_signature_scheme: Some(ECDSA_NISTP256_SHA256) }", format!("{:?}", key));
         assert!(key
             .choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA1])

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -57,7 +57,9 @@ fn alpn_test_error(
 
     for version in rustls::ALL_VERSIONS {
         let mut client_config = make_client_config_with_versions(KeyType::Rsa, &[version]);
-        client_config.alpn_protocols.clone_from(&client_protos);
+        client_config
+            .alpn_protocols
+            .clone_from(&client_protos);
 
         let (mut client, mut server) = make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use primary_provider::rng::rng_new;
 use primary_provider::sign::MbedTlsPkSigningKey as RsaSigningKey;
 use primary_provider::{mbedtls_crypto_provider, MbedtlsSecureRandom};
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption};
@@ -2135,7 +2136,7 @@ fn server_exposes_offered_sni_even_if_resolver_fails() {
 fn sni_resolver_works() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
     resolver
         .add("localhost", sign::CertifiedKey::new(kt.get_chain(), signing_key.clone()))
@@ -2165,7 +2166,7 @@ fn sni_resolver_works() {
 fn sni_resolver_rejects_wrong_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2186,7 +2187,7 @@ fn sni_resolver_rejects_wrong_names() {
 fn sni_resolver_lower_cases_configured_names() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2209,7 +2210,7 @@ fn sni_resolver_lower_cases_queried_names() {
     // actually, the handshake parser does this, but the effect is the same.
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(
@@ -2231,7 +2232,7 @@ fn sni_resolver_lower_cases_queried_names() {
 fn sni_resolver_rejects_bad_certs() {
     let kt = KeyType::Rsa;
     let mut resolver = rustls::server::ResolvesServerCertUsingSni::new();
-    let signing_key = RsaSigningKey::new(&kt.get_key()).unwrap();
+    let signing_key = RsaSigningKey::new(&kt.get_key(), rng_new).unwrap();
     let signing_key: Arc<dyn sign::SigningKey> = Arc::new(signing_key);
 
     assert_eq!(

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use primary_provider::rng::rng_new;
-use primary_provider::sign::MbedTlsPkSigningKey as RsaSigningKey;
+use primary_provider::sign::MbedTlsPkSigningKeyWrapper as RsaSigningKey;
 use primary_provider::{mbedtls_crypto_provider, MbedtlsSecureRandom};
 use rustls::client::{verify_server_cert_signed_by_trust_anchor, ResolvesClientCert, Resumption};
 use rustls::crypto::CryptoProvider;
@@ -57,7 +57,7 @@ fn alpn_test_error(
 
     for version in rustls::ALL_VERSIONS {
         let mut client_config = make_client_config_with_versions(KeyType::Rsa, &[version]);
-        client_config.alpn_protocols = client_protos.clone();
+        client_config.alpn_protocols.clone_from(&client_protos);
 
         let (mut client, mut server) = make_pair_for_arc_configs(&Arc::new(client_config), &server_config);
 

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -398,8 +398,8 @@ pub fn make_server_config_with_client_verifier(kt: KeyType, verifier_builder: Cl
 
 pub fn finish_client_config(kt: KeyType, config: rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier>) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
-    let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
-    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).map(|result| result.unwrap()));
+    let mut root_buf = io::BufReader::new(kt.bytes_for("ca.cert"));
+    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut root_buf).map(|result| result.unwrap()));
 
     config
         .with_root_certificates(root_store)
@@ -411,9 +411,9 @@ pub fn finish_client_config_with_creds(
     config: rustls::ConfigBuilder<ClientConfig, rustls::WantsVerifier>,
 ) -> ClientConfig {
     let mut root_store = RootCertStore::empty();
-    let mut rootbuf = io::BufReader::new(kt.bytes_for("ca.cert"));
+    let mut root_buf = io::BufReader::new(kt.bytes_for("ca.cert"));
     // Passing a reference here just for testing.
-    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut rootbuf).map(|result| result.unwrap()));
+    root_store.add_parsable_certificates(rustls_pemfile::certs(&mut root_buf).map(|result| result.unwrap()));
 
     config
         .with_root_certificates(root_store)
@@ -633,17 +633,17 @@ pub fn server_name(name: &'static str) -> ServerName {
 }
 
 pub struct FailsReads {
-    errkind: io::ErrorKind,
+    error_kind: io::ErrorKind,
 }
 
 impl FailsReads {
-    pub fn new(errkind: io::ErrorKind) -> Self {
-        Self { errkind }
+    pub fn new(error_kind: io::ErrorKind) -> Self {
+        Self { error_kind }
     }
 }
 
 impl io::Read for FailsReads {
     fn read(&mut self, _b: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::from(self.errkind))
+        Err(io::Error::from(self.error_kind))
     }
 }

--- a/rustls-mbedcrypto-provider/tests/common/mod.rs
+++ b/rustls-mbedcrypto-provider/tests/common/mod.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 use std::sync::Arc;
 
 use rustls::crypto::cipher::OutboundOpaqueMessage;
@@ -117,8 +117,8 @@ embed_files! {
 }
 
 pub fn transfer(
-    left: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    right: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;
@@ -146,7 +146,7 @@ pub fn transfer(
     total
 }
 
-pub fn transfer_eof(conn: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>)) {
+pub fn transfer_eof(conn: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>) {
     let empty_buf = [0u8; 0];
     let empty_cursor: &mut dyn io::Read = &mut &empty_buf[..];
     let sz = conn.read_tls(empty_cursor).unwrap();
@@ -563,8 +563,8 @@ pub fn make_pair_for_arc_configs(
 }
 
 pub fn do_handshake(
-    client: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    server: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    client: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    server: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> (usize, usize) {
     let (mut to_client, mut to_server) = (0, 0);
     while server.is_handshaking() || client.is_handshaking() {

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -7,10 +7,7 @@
 
 use std::io;
 
-use core::{
-    fmt::Debug,
-    ops::{Deref, DerefMut},
-};
+use core::{fmt::Debug, ops::DerefMut};
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::{client::danger::ServerCertVerifier, ClientConnection, ConnectionCommon, ServerConnection, SideData};
@@ -34,8 +31,8 @@ pub(crate) fn get_key(bytes: &[u8]) -> PrivateKeyDer {
 
 // Copied from rustls repo
 pub(crate) fn transfer(
-    left: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
-    right: &mut (impl DerefMut + Deref<Target = ConnectionCommon<impl SideData>>),
+    left: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
+    right: &mut impl DerefMut<Target = ConnectionCommon<impl SideData>>,
 ) -> usize {
     let mut buf = [0u8; 262144];
     let mut total = 0;


### PR DESCRIPTION
## TL;DR

This PR picks changes in https://github.com/fortanix/rustls-mbedtls-provider/pull/64 to master.

## Background

Current two RNG we provided in this crate does not meet FIPS requirements.

So, this PR updates all crypto algorithms that need to use RNG to have a function pointer for creating RNG. In this way, user could customize the RNG they want to use for each algorithm.

## Changes

- Update code and add `fn with_rng_provider` to enable user to choose RNG for each crypto algorithm implementation.
- Make some more types `pub`, so user could easily customize current crypto algorithm implementations.
- Add unit tests.
- Fix latest warnings from nightly rust:
  - Remove unnecessary namespace path used in types.
  - Remove unnecessary `Deref` trait guard.