### PR TITLE
Bump rustls version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4d6d8ad9f2492485e13453acbb291dd08f64441b6609c491f1c2cd2c6b4fe1"
+checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
 dependencies = [
  "log",
  "once_cell",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 env_logger = "0.11"
-rustls = { version = "0.23.4", default-features = false, features = [
+rustls = { version = "0.23.5", default-features = false, features = [
   "logging",
   "std",
   "tls12",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
 mbedtls = { version = "0.12.3", default-features = false, features = ["std"] }
-rustls = { version = "0.23.4", default-features = false, features = ["std"] }
+rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [
   "alloc",
@@ -27,7 +27,7 @@ yasna = { version = "0.3", default-features = false, features = ["bit-vec"] }
 bencher = "0.1.5"
 env_logger = "0.10"
 log = { version = "0.4" }
-rustls = { version = "0.23.4", default-features = false, features = [
+rustls = { version = "0.23.5", default-features = false, features = [
   "ring",
   "std",
 ] }

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -17,7 +17,7 @@ mbedtls = { version = "0.12.3", default_features = false, features = [
   "std",
   "x509",
 ] }
-rustls = { version = "0.23.4", default_features = false }
+rustls = { version = "0.23.5", default_features = false }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 x509-parser = "0.15"
 
@@ -25,7 +25,7 @@ x509-parser = "0.15"
 mbedtls = { version = "0.12.2", default_features = false, features = [
   "time",
 ] } # We enable the time feature for tests to make sure it does not mess up cert expiration checking
-rustls = { version = "0.23.4", default-features = false, features = [
+rustls = { version = "0.23.5", default-features = false, features = [
   "ring",
   "std",
   "tls12",

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -13,4 +13,4 @@ resolver = "2"
 
 [dependencies]
 mbedtls = { version = "0.12.3", default-features = false, features = ["std"] }
-rustls = { version = "0.23.4", default-features = false, features = ["std"] }
+rustls = { version = "0.23.5", default-features = false, features = ["std"] }


### PR DESCRIPTION
Upgrade `rustls` version to `0.23.5` to include fix of https://github.com/rustls/rustls/security/advisories/GHSA-6g7w-8wpp-frhj