### PR TITLE
ci: fix ci on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
 
       - name: cargo test (debug; all features)
-        # all features include `rdrand` which is not avaialbe on macos which using arm cpu
+        # all features include `rdrand` which is not available on macos which uses an arm cpu
         if: ${{ matrix.os != 'macos-latest' }}
         run: cargo test --locked --all-features
         shell: bash
@@ -67,7 +67,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; all features available on macos)
-        # all features include `rdrand` which is not avaialbe on macos which using arm cpu
+        # all features include `rdrand` which is not available on macos which uses an arm cpu
         if: ${{ matrix.os == 'macos-latest' }}
         run: cargo test --locked --features fips
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,17 @@ jobs:
         shell: bash
 
       - name: cargo test (debug; all features)
+        # all features include `rdrand` which is not avaialbe on macos which using arm cpu
+        if: ${{ matrix.os != 'macos-latest' }}
         run: cargo test --locked --all-features
+        shell: bash
+        env:
+          RUST_BACKTRACE: 1
+
+      - name: cargo test (debug; all features available on macos)
+        # all features include `rdrand` which is not avaialbe on macos which using arm cpu
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: cargo test --locked --features fips
         shell: bash
         env:
           RUST_BACKTRACE: 1


### PR DESCRIPTION
Not use `rdrand` feature when running CI on macos, since
`rdrand` is only available on intel cpu but macos VM cpu does not
support it.

Fixs #75