### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,7 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
-  groups:
-    crates-io:
-      patterns:
-        - "*"
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
Disable group updates since they are always failing. Ask dependabot to update dependency one by one is better.