### PR TITLE
Upgrade Rustls from v0.23.5 to v0.23.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 env_logger = "0.11"
-rustls = { version = "0.23.5", default-features = false, features = [
+rustls = { version = "0.23.21", default-features = false, features = [
   "logging",
   "std",
   "tls12",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
 mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
-rustls = { version = "0.23.5", default-features = false, features = ["std"] }
+rustls = { version = "0.23.21", default-features = false, features = ["std"] }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [
   "alloc",
@@ -27,7 +27,7 @@ yasna = { version = "0.3", default-features = false, features = ["bit-vec"] }
 bencher = "0.1.5"
 env_logger = "0.10"
 log = { version = "0.4" }
-rustls = { version = "0.23.5", default-features = false, features = [
+rustls = { version = "0.23.21", default-features = false, features = [
   "ring",
   "std",
 ] }

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -17,7 +17,7 @@ mbedtls = { version = "0.13.0", default-features = false, features = [
   "std",
   "x509",
 ] }
-rustls = { version = "0.23.5", default-features = false }
+rustls = { version = "0.23.21", default-features = false }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 x509-parser = "0.15"
 
@@ -25,7 +25,7 @@ x509-parser = "0.15"
 mbedtls = { version = "0.13.0", default-features = false, features = [
   "time",
 ] } # We enable the time feature for tests to make sure it does not mess up cert expiration checking
-rustls = { version = "0.23.5", default-features = false, features = [
+rustls = { version = "0.23.21", default-features = false, features = [
   "ring",
   "std",
   "tls12",

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 
 [dependencies]
 mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
-rustls = { version = "0.23.5", default-features = false, features = ["std"] }
+rustls = { version = "0.23.21", default-features = false, features = ["std"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(bench)'] }


### PR DESCRIPTION
This PR:
- Upgrades the Rustls crate
- Updates the associated lock files