### PR TITLE
Update to mbedtls v0.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,8 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "mbedtls"
 version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb35c8dbebb68daa60498d015c440b9c5f449c740357ba877129761d68fd435"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -511,6 +513,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -521,6 +525,8 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.28.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d12704ff5afaa855500ac08b955ff7bb0cef94eb10983da6a1b6c6ffe74a070"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1a79c64122e22312679a350d1c8e6b21605b3836ee5d8fe3722f1d0187a6f7"
+version = "0.13.1"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -513,8 +511,6 @@ dependencies = [
 [[package]]
 name = "mbedtls-platform-support"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -524,9 +520,7 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bb8ccdfd2a163117d977677665a2008fbd9ab38c884b0b8a57828219868dc0"
+version = "2.28.11"
 dependencies = [
  "bindgen",
  "cc",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [dependencies]
 bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
-mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.1", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 chrono = "0.4"
-mbedtls = { version = "0.13.0", default-features = false, features = [
+mbedtls = { version = "0.13.1", default-features = false, features = [
   "chrono",
   "std",
   "x509",
@@ -22,7 +22,7 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 x509-parser = "0.17"
 
 [dev-dependencies]
-mbedtls = { version = "0.13.0", default-features = false, features = [
+mbedtls = { version = "0.13.1", default-features = false, features = [
   "time",
 ] } # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 rustls = { version = "0.23.5", default-features = false, features = [

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/fortanix/rustls-mbedtls-provider"
 resolver = "2"
 
 [dependencies]
-mbedtls = { version = "0.13.0", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.1", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 
 [lints.rust]


### PR DESCRIPTION
mbedtls_v0.13.1 has lowered serde dependency version to 1.0.7 (as previous).
this PR updated rustls-mbedtls-provider to point to that version of mbedtls_v0.13.1