### PR TITLE
New version with updated deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,9 +845,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "mbedtls-sys-auto"
-version = "2.28.11"
+version = "2.28.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d12704ff5afaa855500ac08b955ff7bb0cef94eb10983da6a1b6c6ffe74a070"
+checksum = "225db657202fc57aea23750995667c399a9250238268bff9ab15053b2ccaad8c"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedcrypto-provider"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bencher",
  "bit-vec 0.6.3",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedpki-provider"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "mbedtls",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-mbedtls-provider-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "mbedtls",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb35c8dbebb68daa60498d015c440b9c5f449c740357ba877129761d68fd435"
+checksum = "5d89abdbbea62adc59aa54848c845ef789481a60d66f6dd5df746cf1069ff068"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d89abdbbea62adc59aa54848c845ef789481a60d66f6dd5df746cf1069ff068"
+checksum = "8b8114ab6c15889057a80479744eeb891e090ed2dd0258f13a7ef8ef02848293"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [dependencies]
 bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
-mbedtls = { version = "0.13.2", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.3", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedcrypto-provider"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Fortanix Inc."]
 categories = ["cryptography", "network-programming"]
 description = "Mbedtls based crypto provider for rustls."
@@ -16,7 +16,7 @@ bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
 mbedtls = { version = "0.13.3", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
-utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
+utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.1" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [
   "alloc",
   "std",

--- a/rustls-mbedcrypto-provider/Cargo.toml
+++ b/rustls-mbedcrypto-provider/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [dependencies]
 bit-vec = "0.6.3"
 log = { version = "0.4", optional = true }
-mbedtls = { version = "0.13.1", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.2", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
 webpki = { package = "rustls-webpki", version = "0.102.0", default-features = false, features = [

--- a/rustls-mbedcrypto-provider/examples/internal/bench_impl.rs
+++ b/rustls-mbedcrypto-provider/examples/internal/bench_impl.rs
@@ -52,8 +52,8 @@ where
         times.push(duration_nanos(Instant::now().duration_since(start)));
     }
 
-    println!("{}", name);
-    println!("{:?}", times);
+    println!("{name}");
+    println!("{times:?}");
 }
 
 fn time<F>(mut f: F) -> f64
@@ -105,7 +105,7 @@ where
                     offs += read;
                 }
                 Err(err) => {
-                    panic!("error on transfer {}..{}: {}", offs, sz, err);
+                    panic!("error on transfer {offs}..{sz}: {err}");
                 }
             }
 
@@ -114,7 +114,7 @@ where
                     let sz = match right.reader().read(&mut data_buf) {
                         Ok(sz) => sz,
                         Err(err) if err.kind() == io::ErrorKind::WouldBlock => break,
-                        Err(err) => panic!("failed to read data: {}", err),
+                        Err(err) => panic!("failed to read data: {err}"),
                     };
 
                     *left -= sz;
@@ -247,8 +247,8 @@ static ALL_BENCHMARKS: &[BenchmarkParam] = &[
 impl KeyType {
     fn path_for(&self, part: &str) -> String {
         match self {
-            Self::Rsa => format!("test-ca/rsa/{}", part),
-            Self::Ecdsa => format!("test-ca/ecdsa/{}", part),
+            Self::Rsa => format!("test-ca/rsa/{part}"),
+            Self::Ecdsa => format!("test-ca/ecdsa/{part}"),
             // Ed25519 is not supported by *mbedtls*
             // Self::Ed25519 => format!("test-ca/eddsa/{}", part),
         }
@@ -542,7 +542,7 @@ fn lookup_matching_benches(name: &str) -> Vec<&BenchmarkParam> {
         .collect();
 
     if r.is_empty() {
-        panic!("unknown suite {:?}", name);
+        panic!("unknown suite {name:?}");
     }
 
     r
@@ -614,7 +614,7 @@ fn selected_tests(mut args: env::Args) {
         },
 
         _ => {
-            panic!("unsupported mode {:?}", mode);
+            panic!("unsupported mode {mode:?}");
         }
     }
 }

--- a/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
+++ b/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
@@ -46,7 +46,7 @@ impl fmt::Display for FipsCheckError {
 }
 
 #[allow(clippy::std_instead_of_core)]
-impl std::error::Error for FipsCheckError {}
+impl core::error::Error for FipsCheckError {}
 
 impl From<FipsCheckError> for rustls::Error {
     fn from(value: FipsCheckError) -> Self {

--- a/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
+++ b/rustls-mbedcrypto-provider/src/fips_utils/mod.rs
@@ -39,8 +39,8 @@ pub enum FipsCheckError {
 impl fmt::Display for FipsCheckError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Mbedtls(_) => write!(f, "FipsCheckError::{:?}", self),
-            Self::General(err_str) => write!(f, "FipsCheckError::General({})", err_str),
+            Self::Mbedtls(_) => write!(f, "FipsCheckError::{self:?}"),
+            Self::General(err_str) => write!(f, "FipsCheckError::General({err_str})"),
         }
     }
 }
@@ -275,13 +275,13 @@ mod tests {
     #[test]
     fn test_fips_check_error_display() {
         let error = FipsCheckError::Mbedtls(mbedtls::error::codes::EcpAllocFailed.into());
-        assert_eq!(format!("{}", error), "FipsCheckError::Mbedtls(HighLevel(EcpAllocFailed))");
+        assert_eq!(format!("{error}"), "FipsCheckError::Mbedtls(HighLevel(EcpAllocFailed))");
         let error = FipsCheckError::General(Cow::Borrowed("Some other error"));
-        assert_eq!(format!("{}", error), "FipsCheckError::General(Some other error)");
+        assert_eq!(format!("{error}"), "FipsCheckError::General(Some other error)");
         let error = FipsCheckError::Mbedtls(mbedtls::error::codes::EcpAllocFailed.into());
-        assert_eq!(format!("{:?}", error), "Mbedtls(HighLevel(EcpAllocFailed))");
+        assert_eq!(format!("{error:?}"), "Mbedtls(HighLevel(EcpAllocFailed))");
         let error_other = FipsCheckError::General(Cow::Borrowed("Some other error"));
-        assert_eq!(format!("{:?}", error_other), "General(\"Some other error\")");
+        assert_eq!(format!("{error_other:?}"), "General(\"Some other error\")");
     }
 
     #[test]
@@ -345,14 +345,14 @@ mod tests {
     fn print_vec(name: &str, val: &[u8]) {
         let formatted_strings: Vec<String> = val
             .iter()
-            .map(|byte| format!("0x{:02x}", byte))
+            .map(|byte| format!("0x{byte:02x}"))
             .collect();
 
         // Join the formatted strings with commas
         let formatted_output = formatted_strings.join(",");
 
         // Print the output, enclosed in brackets
-        println!("{}:\n[{}]", name, formatted_output);
+        println!("{name}:\n[{formatted_output}]");
     }
 
     #[test]

--- a/rustls-mbedcrypto-provider/src/hash.rs
+++ b/rustls-mbedcrypto-provider/src/hash.rs
@@ -121,13 +121,13 @@ impl MbedHashContext {
                 match ctx.finish(&mut out) {
                     Ok(_) => out,
                     Err(_err) => {
-                        error!("Failed to finalize hash, mbedtls error: {:?}", _err);
+                        error!("Failed to finalize hash, mbedtls error: {_err:?}");
                         vec![]
                     }
                 }
             }
             Err(_err) => {
-                error!("Failed to get lock, error: {:?}", _err);
+                error!("Failed to get lock, error: {_err:?}");
                 vec![]
             }
         }
@@ -138,11 +138,11 @@ impl MbedHashContext {
             Ok(ctx) => match ctx.update(data) {
                 Ok(_) => {}
                 Err(_err) => {
-                    error!("Failed to update hash, mbedtls error: {:?}", _err);
+                    error!("Failed to update hash, mbedtls error: {_err:?}");
                 }
             },
             Err(_err) => {
-                error!("Failed to get lock, error: {:?}", _err);
+                error!("Failed to get lock, error: {_err:?}");
             }
         }
     }
@@ -153,7 +153,7 @@ pub(crate) fn hash(hash_algo: &'static Algorithm, data: &[u8]) -> Vec<u8> {
     match mbedtls::hash::Md::hash(hash_algo.hash_type, data, &mut out) {
         Ok(_) => out,
         Err(_err) => {
-            error!("Failed to do hash, mbedtls error: {:?}", _err);
+            error!("Failed to do hash, mbedtls error: {_err:?}");
             vec![]
         }
     }

--- a/rustls-mbedcrypto-provider/src/hmac.rs
+++ b/rustls-mbedcrypto-provider/src/hmac.rs
@@ -89,7 +89,7 @@ impl MbedHmacContext {
         match self.ctx.finish(out.as_mut()) {
             Ok(_) => out,
             Err(_err) => {
-                error!("Failed to finish hmac, mbedtls error: {:?}", _err);
+                error!("Failed to finish hmac, mbedtls error: {_err:?}");
                 Tag::with_len(0)
             }
         }
@@ -99,7 +99,7 @@ impl MbedHmacContext {
         match self.ctx.update(data) {
             Ok(_) => {}
             Err(_err) => {
-                error!("Failed to update hmac, mbedtls error: {:?}", _err);
+                error!("Failed to update hmac, mbedtls error: {_err:?}");
             }
         }
     }

--- a/rustls-mbedcrypto-provider/src/kx.rs
+++ b/rustls-mbedcrypto-provider/src/kx.rs
@@ -112,7 +112,7 @@ impl<T: RngCallback + 'static> SupportedKxGroup for EcdhKxGroupWrapper<T> {
 #[inline]
 fn generate_ec_key<F: Random>(group_id: mbedtls::pk::EcGroupId, rng: &mut F) -> Result<PkMbed, Error> {
     PkMbed::generate_ec(rng, group_id)
-        .map_err(|err| Error::General(format!("Got error when generating ec key, mbedtls error: {}", err)))
+        .map_err(|err| Error::General(format!("Got error when generating ec key, mbedtls error: {err}")))
 }
 
 /// Ephemeral ECDH on curve25519 (see RFC7748)
@@ -331,7 +331,7 @@ impl<T: RngCallback> SupportedKxGroup for FfdheKxGroupWrapper<T> {
         let mut x = vec![0; self.dhe_kx_group.priv_key_len];
         rng.random(&mut x)
             .map_err(|_| crypto::GetRandomFailed)?;
-        let x = Mpi::from_binary(&x).map_err(|e| Error::General(format!("failed to make Bignum from random bytes: {}", e)))?;
+        let x = Mpi::from_binary(&x).map_err(|e| Error::General(format!("failed to make Bignum from random bytes: {e}")))?;
         let x_pub = g
             .mod_exp(&x, &p)
             .map_err(mbedtls_err_to_rustls_error)?;
@@ -443,7 +443,7 @@ mod tests {
 
     #[test]
     fn test_kx_group_fmt_debug() {
-        let debug_str = format!("{:?}", X25519_KX_GROUP);
+        let debug_str = format!("{X25519_KX_GROUP:?}");
         assert_eq!(
             debug_str,
             "EcdhKxGroupWrapper { kx_group: EcdhKxGroup { agreement_algorithm: Algorithm { group_id: Curve25519 }, name: X25519 } }",
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_dhe_kx_group_fmt_debug() {
-        let debug_str = format!("{:?}", FFDHE2048_KX_GROUP);
+        let debug_str = format!("{FFDHE2048_KX_GROUP:?}");
         assert!(debug_str.contains("FfdheKxGroup"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FFDHE2048"), "debug_str: {debug_str}");
         assert!(debug_str.contains("FfdheGroup"), "debug_str: {debug_str}");

--- a/rustls-mbedcrypto-provider/src/sign.rs
+++ b/rustls-mbedcrypto-provider/src/sign.rs
@@ -197,14 +197,14 @@ mod tests {
                 .unwrap()
                 .into();
         let key = MbedTlsPkSigningKeyWrapper::new(&der, crate::rng::rng_new).unwrap();
-        assert_eq!(format!("{:?}", key), "MbedTlsPkSigningKeyWrapper { signing_key: MbedTlsPkSigningKeyWrapper { pk: \"Arc<Mutex<mbedtls::pk::Pk>>\", pk_type: Eckey, signature_algorithm: ECDSA, ec_signature_scheme: Some(ECDSA_NISTP256_SHA256) } }");
+        assert_eq!(format!("{key:?}"), "MbedTlsPkSigningKeyWrapper { signing_key: MbedTlsPkSigningKeyWrapper { pk: \"Arc<Mutex<mbedtls::pk::Pk>>\", pk_type: Eckey, signature_algorithm: ECDSA, ec_signature_scheme: Some(ECDSA_NISTP256_SHA256) } }");
         assert!(key
             .choose_scheme(&[SignatureScheme::RSA_PKCS1_SHA1])
             .is_none());
         let res = key.choose_scheme(&[SignatureScheme::ECDSA_NISTP256_SHA256]);
         assert!(res.is_some());
         assert_eq!(
-            format!("{:?}", res),
+            format!("{res:?}"),
             "Some(MbedTlsSigner(\"Arc<Mutex<mbedtls::pk::Pk>>\", ECDSA_NISTP256_SHA256))",
         );
     }

--- a/rustls-mbedcrypto-provider/src/tls13.rs
+++ b/rustls-mbedcrypto-provider/src/tls13.rs
@@ -234,9 +234,7 @@ struct MbedHkdfHmacExpander {
 impl HkdfExpander for MbedHkdfHmacExpander {
     fn expand_slice(&self, info: &[&[u8]], output: &mut [u8]) -> Result<(), OutputLengthError> {
         let prf = self.prf_res.as_ref().map_err(|_err| {
-            error!(
-                "MbedHkdfExpander::expand_slice got mbedtls error from creation call in Hkdf trait: {_err:?}"
-            );
+            error!("MbedHkdfExpander::expand_slice got mbedtls error from creation call in Hkdf trait: {_err:?}");
             OutputLengthError
         })?;
         let info: Vec<u8> = info
@@ -252,9 +250,7 @@ impl HkdfExpander for MbedHkdfHmacExpander {
 
     fn expand_block(&self, info: &[&[u8]]) -> OkmBlock {
         if let Err(_err) = self.prf_res.as_ref() {
-            error!(
-                "MbedHkdfExpander::expand_block got mbedtls error from creation call in Hkdf trait: {_err:?}"
-            );
+            error!("MbedHkdfExpander::expand_block got mbedtls error from creation call in Hkdf trait: {_err:?}");
             return OkmBlock::new(&[]);
         }
         let prf = self

--- a/rustls-mbedcrypto-provider/src/tls13.rs
+++ b/rustls-mbedcrypto-provider/src/tls13.rs
@@ -235,8 +235,7 @@ impl HkdfExpander for MbedHkdfHmacExpander {
     fn expand_slice(&self, info: &[&[u8]], output: &mut [u8]) -> Result<(), OutputLengthError> {
         let prf = self.prf_res.as_ref().map_err(|_err| {
             error!(
-                "MbedHkdfExpander::expand_slice got mbedtls error from creation call in Hkdf trait: {:?}",
-                _err
+                "MbedHkdfExpander::expand_slice got mbedtls error from creation call in Hkdf trait: {_err:?}"
             );
             OutputLengthError
         })?;
@@ -246,7 +245,7 @@ impl HkdfExpander for MbedHkdfHmacExpander {
             .cloned()
             .collect();
         mbedtls::hash::Hkdf::hkdf_expand(self.hash_alg.hash_type, prf.as_ref(), &info, output).map_err(|_err| {
-            error!("MbedHkdfExpander::expand_slice got mbedtls error: {:?}", _err);
+            error!("MbedHkdfExpander::expand_slice got mbedtls error: {_err:?}");
             OutputLengthError
         })
     }
@@ -254,8 +253,7 @@ impl HkdfExpander for MbedHkdfHmacExpander {
     fn expand_block(&self, info: &[&[u8]]) -> OkmBlock {
         if let Err(_err) = self.prf_res.as_ref() {
             error!(
-                "MbedHkdfExpander::expand_block got mbedtls error from creation call in Hkdf trait: {:?}",
-                _err
+                "MbedHkdfExpander::expand_block got mbedtls error from creation call in Hkdf trait: {_err:?}"
             );
             return OkmBlock::new(&[]);
         }
@@ -270,7 +268,7 @@ impl HkdfExpander for MbedHkdfHmacExpander {
             .cloned()
             .collect();
         let _ = mbedtls::hash::Hkdf::hkdf_expand(self.hash_alg.hash_type, prf.as_ref(), &info, tag.as_mut())
-            .map_err(|_err| error!("MbedHkdfExpander::expand_block got mbedtls error: {:?}", _err));
+            .map_err(|_err| error!("MbedHkdfExpander::expand_block got mbedtls error: {_err:?}"));
         OkmBlock::new(tag.as_ref())
     }
 

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -130,7 +130,7 @@ fn version_test(
     let client_config = make_client_config_with_versions(KeyType::Rsa, client_versions);
     let server_config = make_server_config_with_versions(KeyType::Rsa, server_versions);
 
-    println!("version {:?} {:?} -> {:?}", client_versions, server_versions, result);
+    println!("version {client_versions:?} {server_versions:?} -> {result:?}");
 
     let (mut client, mut server) = make_pair_for_configs(client_config, server_config);
 
@@ -1690,7 +1690,7 @@ fn client_read_returns_wouldblock_when_no_data() {
 fn new_server_returns_initial_io_state() {
     let (_, mut server) = make_pair(KeyType::Rsa);
     let io_state = server.process_new_packets().unwrap();
-    println!("IoState is Debug {:?}", io_state);
+    println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
     assert_eq!(io_state.tls_bytes_to_write(), 0);
@@ -1700,7 +1700,7 @@ fn new_server_returns_initial_io_state() {
 fn new_client_returns_initial_io_state() {
     let (mut client, _) = make_pair(KeyType::Rsa);
     let io_state = client.process_new_packets().unwrap();
-    println!("IoState is Debug {:?}", io_state);
+    println!("IoState is Debug {io_state:?}");
     assert_eq!(io_state.plaintext_bytes_to_read(), 0);
     assert!(!io_state.peer_has_closed());
     assert!(io_state.tls_bytes_to_write() > 200);
@@ -2078,7 +2078,7 @@ fn stream_write_swallows_underlying_io_error_after_plaintext_processed() {
         .unwrap();
     let mut client_stream = Stream::new(&mut client, &mut pipe);
     let rc = client_stream.write(b"world");
-    assert_eq!(format!("{:?}", rc), "Ok(5)");
+    assert_eq!(format!("{rc:?}"), "Ok(5)");
 }
 
 #[test]
@@ -3456,7 +3456,7 @@ fn test_client_attempts_to_use_unsupported_kx_group() {
     do_handshake_until_error(&mut client_1, &mut server).unwrap();
 
     let ops = shared_storage.ops();
-    println!("storage {:#?}", ops);
+    println!("storage {ops:#?}");
     assert_eq!(ops.len(), 9);
     assert!(matches!(ops[3], ClientStorageOp::SetKxHint(_, rustls::NamedGroup::X25519)));
 
@@ -3496,7 +3496,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     do_handshake_until_error(&mut client, &mut server).unwrap();
 
     let ops = shared_storage.ops_and_reset();
-    println!("storage {:#?}", ops);
+    println!("storage {ops:#?}");
     assert_eq!(ops.len(), 10);
     assert!(matches!(ops[5], ClientStorageOp::InsertTls13Ticket(_)));
     assert!(matches!(ops[6], ClientStorageOp::InsertTls13Ticket(_)));
@@ -3527,7 +3527,7 @@ fn test_tls13_client_resumption_does_not_reuse_tickets() {
     server.process_new_packets().unwrap();
 
     let ops = shared_storage.ops_and_reset();
-    println!("last {:?}", ops);
+    println!("last {ops:?}");
     assert!(matches!(ops[0], ClientStorageOp::TakeTls13Ticket(_, false)));
 }
 
@@ -3570,7 +3570,7 @@ fn test_client_mtu_reduction() {
         client_config.max_fragment_size = Some(64);
         let mut client = ClientConnection::new(Arc::new(client_config), server_name("localhost")).unwrap();
         let writes = collect_write_lengths(&mut client);
-        println!("writes at mtu=64: {:?}", writes);
+        println!("writes at mtu=64: {writes:?}");
         assert!(writes.iter().all(|x| *x <= 64));
         assert!(writes.len() > 1);
     }
@@ -3672,7 +3672,7 @@ fn handshakes_complete_and_data_flows_with_gratuitious_max_fragment_sizes() {
 
 fn assert_lt(left: usize, right: usize) {
     if left >= right {
-        panic!("expected {} < {}", left, right);
+        panic!("expected {left} < {right}");
     }
 }
 
@@ -3769,7 +3769,7 @@ fn test_server_rejects_clients_without_any_kx_group_overlap() {
 fn test_client_rejects_illegal_tls13_ccs() {
     fn corrupt_ccs(msg: &mut Message) -> Altered {
         if let MessagePayload::ChangeCipherSpec(_) = &mut msg.payload {
-            println!("seen CCS {:?}", msg);
+            println!("seen CCS {msg:?}");
             return Altered::Raw(vec![0x14, 0x03, 0x03, 0x00, 0x02, 0x01, 0x02]);
         }
         Altered::InPlace
@@ -4142,7 +4142,7 @@ fn test_ffdhe_bad_pub_key_is_rejected() {
         let handshake_res = do_handshake_until_error(&mut client, &mut server);
 
         let ErrorFromPeer::Client(client_err) = handshake_res.as_ref().unwrap_err() else {
-            panic!("Unexpected error from server: {:?}", handshake_res)
+            panic!("Unexpected error from server: {handshake_res:?}")
         };
         assert!(dbg!(client_err.to_string()).contains("pub key must be in range (1, p-1)"));
     }

--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -1384,7 +1384,7 @@ fn client_flush_does_nothing() {
     assert!(matches!(client.writer().flush(), Ok(())));
 }
 
-#[allow(clippy::no_effect)]
+#[allow(clippy::no_effect, clippy::unnecessary_operation)]
 #[test]
 fn server_is_send_and_sync() {
     let (_, server) = make_pair(KeyType::Rsa);
@@ -1392,7 +1392,7 @@ fn server_is_send_and_sync() {
     &server as &dyn Sync;
 }
 
-#[allow(clippy::no_effect)]
+#[allow(clippy::no_effect, clippy::unnecessary_operation)]
 #[test]
 fn client_is_send_and_sync() {
     let (client, _) = make_pair(KeyType::Rsa);
@@ -1575,7 +1575,7 @@ where
     C: DerefMut + Deref<Target = ConnectionCommon<S>>,
     S: SideData,
 {
-    fn new(sess: &mut C) -> OtherSession<C, S> {
+    fn new(sess: &mut C) -> OtherSession<'_, C, S> {
         OtherSession {
             sess,
             reads: 0,
@@ -1588,7 +1588,7 @@ where
         }
     }
 
-    fn new_buffered(sess: &mut C) -> OtherSession<C, S> {
+    fn new_buffered(sess: &mut C) -> OtherSession<'_, C, S> {
         let mut os = OtherSession::new(sess);
         os.buffered = true;
         os

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 chrono = "0.4"
-mbedtls = { version = "0.13.2", default-features = false, features = [
+mbedtls = { version = "0.13.3", default-features = false, features = [
   "chrono",
   "std",
   "x509",
@@ -22,7 +22,7 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 x509-parser = "0.17"
 
 [dev-dependencies]
-mbedtls = { version = "0.13.2", default-features = false, features = [
+mbedtls = { version = "0.13.3", default-features = false, features = [
   "time",
 ] } # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 rustls = { version = "0.23.5", default-features = false, features = [

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedpki-provider"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix Inc."]
 categories = ["cryptography", "network-programming"]
 description = "Implements rustls PKI traits using mbedtls"
@@ -18,7 +18,7 @@ mbedtls = { version = "0.13.3", default-features = false, features = [
   "x509",
 ] }
 rustls = { version = "0.23.5", default-features = false }
-utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.0" }
+utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-provider-utils", version = "0.2.1" }
 x509-parser = "0.17"
 
 [dev-dependencies]

--- a/rustls-mbedpki-provider/Cargo.toml
+++ b/rustls-mbedpki-provider/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [dependencies]
 chrono = "0.4"
-mbedtls = { version = "0.13.1", default-features = false, features = [
+mbedtls = { version = "0.13.2", default-features = false, features = [
   "chrono",
   "std",
   "x509",
@@ -22,7 +22,7 @@ utils = { package = "rustls-mbedtls-provider-utils", path = "../rustls-mbedtls-p
 x509-parser = "0.17"
 
 [dev-dependencies]
-mbedtls = { version = "0.13.1", default-features = false, features = [
+mbedtls = { version = "0.13.2", default-features = false, features = [
   "time",
 ] } # We enable the time feature for tests to make sure it does not mess up cert expiration checking
 rustls = { version = "0.23.5", default-features = false, features = [

--- a/rustls-mbedpki-provider/src/client_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/client_cert_verifier.rs
@@ -241,7 +241,7 @@ mod tests {
         let client_cert_verifier = MbedTlsClientCertVerifier::new([&root_ca]).unwrap();
         assert_eq!(
             r#"MbedTlsClientCertVerifier { trusted_cas: "..", root_subjects: [DistinguishedName(301a3118301606035504030c0f706f6e79746f776e20525341204341)], verify_callback: "..", cert_active_check: CertActiveCheck { ignore_expired: false, ignore_not_active_yet: false } }"#,
-            format!("{:?}", client_cert_verifier)
+            format!("{client_cert_verifier:?}")
         );
     }
 
@@ -471,6 +471,6 @@ mod tests {
         )));
         assert!(verifier.verify_callback().is_some());
         let verify_res = verifier.verify_client_cert(&cert_chain[0], &cert_chain[1..], now);
-        assert!(verify_res.is_ok(), "{:?}", verify_res);
+        assert!(verify_res.is_ok(), "{verify_res:?}");
     }
 }

--- a/rustls-mbedpki-provider/src/lib.rs
+++ b/rustls-mbedpki-provider/src/lib.rs
@@ -207,7 +207,7 @@ impl Display for VerifyErrorWrapper {
 }
 
 #[allow(clippy::std_instead_of_core)]
-impl std::error::Error for VerifyErrorWrapper {}
+impl core::error::Error for VerifyErrorWrapper {}
 
 #[cfg(test)]
 mod tests {

--- a/rustls-mbedpki-provider/src/lib.rs
+++ b/rustls-mbedpki-provider/src/lib.rs
@@ -230,7 +230,7 @@ mod tests {
     fn verify_error_wrapper_display() {
         let verify_error = VerifyError::CERT_EXPIRED; // Replace with actual instantiation of VerifyError
         let wrapper = VerifyErrorWrapper(verify_error);
-        assert_eq!(format!("{}", wrapper), format!("{:?}", verify_error));
+        assert_eq!(format!("{wrapper}"), format!("{:?}", verify_error));
     }
 
     #[test]

--- a/rustls-mbedpki-provider/src/server_cert_verifier.rs
+++ b/rustls-mbedpki-provider/src/server_cert_verifier.rs
@@ -244,7 +244,7 @@ mod tests {
         let server_cert_verifier = MbedTlsServerCertVerifier::new([&root_ca]).unwrap();
         assert_eq!(
             "MbedTlsServerCertVerifier { trusted_cas: \"..\", verify_callback: \"..\", cert_active_check: CertActiveCheck { ignore_expired: false, ignore_not_active_yet: false } }",
-            format!("{:?}", server_cert_verifier)
+            format!("{server_cert_verifier:?}")
         );
     }
 
@@ -474,7 +474,7 @@ mod tests {
                 .unwrap(),
         );
         let verify_res = verifier.verify_server_cert(&cert_chain[0], &cert_chain[1..], &server_name, &[], now);
-        println!("verify res: {:?}", verify_res);
+        println!("verify res: {verify_res:?}");
         assert!(matches!(verify_res, Err(rustls::Error::InvalidCertificate(_))));
     }
 
@@ -492,7 +492,7 @@ mod tests {
                 .unwrap(),
         );
         let verify_res = verifier.verify_server_cert(&cert_chain[0], &cert_chain[1..], &server_name, &[], now);
-        println!("verify res: {:?}", verify_res);
+        println!("verify res: {verify_res:?}");
         assert!(matches!(verify_res, Err(rustls::Error::InvalidCertificate(_))));
 
         verifier.set_verify_callback(Some(Arc::new(

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -13,14 +13,14 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
 use rustls::{client::danger::ServerCertVerifier, ClientConnection, ConnectionCommon, ServerConnection, SideData};
 
 /// Get a certificate chain from the contents of a pem file
-pub(crate) fn get_chain(bytes: &[u8]) -> Vec<CertificateDer> {
+pub(crate) fn get_chain(bytes: &[u8]) -> Vec<CertificateDer<'_>> {
     rustls_pemfile::certs(&mut io::BufReader::new(bytes))
         .map(Result::unwrap)
         .collect()
 }
 
 /// Get a private key from the contents of a pem file
-pub(crate) fn get_key(bytes: &[u8]) -> PrivateKeyDer {
+pub(crate) fn get_key(bytes: &[u8]) -> PrivateKeyDer<'_> {
     let value = rustls_pemfile::pkcs8_private_keys(&mut io::BufReader::new(bytes))
         .next()
         .unwrap()

--- a/rustls-mbedpki-provider/src/tests_common.rs
+++ b/rustls-mbedpki-provider/src/tests_common.rs
@@ -139,6 +139,6 @@ mod tests {
             ],
         };
 
-        assert_eq!("VerifierWithSupportedVerifySchemes { verifier: \"..\", supported_verify_schemes: [RSA_PKCS1_SHA1, ECDSA_NISTP521_SHA512] }",format!("{:?}", verifier));
+        assert_eq!("VerifierWithSupportedVerifySchemes { verifier: \"..\", supported_verify_schemes: [RSA_PKCS1_SHA1, ECDSA_NISTP521_SHA512] }",format!("{verifier:?}"));
     }
 }

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/fortanix/rustls-mbedtls-provider"
 resolver = "2"
 
 [dependencies]
-mbedtls = { version = "0.13.1", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.2", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 
 [lints.rust]

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/fortanix/rustls-mbedtls-provider"
 resolver = "2"
 
 [dependencies]
-mbedtls = { version = "0.13.2", default-features = false, features = ["std"] }
+mbedtls = { version = "0.13.3", default-features = false, features = ["std"] }
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
 
 [lints.rust]

--- a/rustls-mbedtls-provider-utils/Cargo.toml
+++ b/rustls-mbedtls-provider-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-mbedtls-provider-utils"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fortanix Inc."]
 categories = ["cryptography", "network-programming"]
 description = "Utility code used in mbedtls based provider for rustls."


### PR DESCRIPTION
This PR:
- Bump dependency rustls-pki-types from 1.11.0 to 1.12.0
- Bump dependency mbedtls from 0.13.1 to 0.13.3
- Update mbedtls-sys-auto v2.28.11 -> v2.28.12
- Bump rustls-mbedcrypto-provider from 0.1.0 to 0.1.1
- Bump rustls-mbedpki-provider from 0.2.0 to 0.2.1
- Bump rustls-mbedtls-provider-utils from 0.2.0 to 0.2.1

For the new releases of crates:
- `rustls-mbedpki-provider`
  - Updated `mbedtls` 0.12.3 -> 0.13.3
  - Updated `rustls-mbedtls-provider-utils` 0.2.0 -> 0.2.1
  - Updated `x509-parser` 0.15 -> 0.17
- `rustls-mbedcrypto-provider`
  - Updated `mbedtls` 0.12.3 -> 0.13.3
  - Updated `rustls-mbedtls-provider-utils` 0.2.0 -> 0.2.1
  - Loose `webpki-roots` 0.26.1 -> 0.26
- `rustls-mbedtls-provider-utils`
  - Updated `mbedtls` 0.12.3 -> 0.13.3
  - Updated `rustls-native-certs` 0.8.0 -> 0.8.1