### PR TITLE
Remove redundant into_iter() call in add_root_hint_subjects

### DIFF
--- a/rustls-mbedcrypto-provider/tests/api.rs
+++ b/rustls-mbedcrypto-provider/tests/api.rs
@@ -1212,7 +1212,7 @@ fn client_cert_resolve_server_added_hint() {
         // Create a verifier that adds the extra_name as a hint subject in addition to the ones
         // from the root cert store.
         let verifier = webpki_client_verifier_builder(get_client_root_store(key_type))
-            .add_root_hint_subjects([DistinguishedName::from(extra_name.clone())].into_iter());
+            .add_root_hint_subjects([DistinguishedName::from(extra_name.clone())]);
         let server_config = make_server_config_with_client_verifier(key_type, verifier);
         test_client_cert_resolve(key_type, server_config.into(), expected_hint_subjects);
     }


### PR DESCRIPTION
Comes from failure CI: https://github.com/fortanix/rustls-mbedtls-provider/actions/runs/25011727133/job/73248942623?pr=155